### PR TITLE
feat: responsividade mobile (hook, DataTable, dashboard, sidebar drawer)

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { ArrowUp, ArrowDown, ArrowRight } from 'lucide-react'
 import { formatCurrency } from '@/lib/utils'
+import { useIsMobile } from '@/lib/hooks/useMediaQuery'
 
 // ─── types ────────────────────────────────────────────────────────────────────
 
@@ -961,6 +962,7 @@ export default function DashboardPage() {
   }
   const { data: meData } = useQuery({ queryKey: ['me'], queryFn: () => fetch('/api/me').then(r => r.json()) })
   const firstName = meData?.user?.name?.split(' ')[0] ?? ''
+  const isMobile = useIsMobile()
 
   useEffect(() => {
     if (!data) return
@@ -989,7 +991,7 @@ export default function DashboardPage() {
           {sk(200, 36, 100)}
         </div>
         {/* KPI cards */}
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 16, marginBottom: 24 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: isMobile ? 'repeat(2,1fr)' : 'repeat(4,1fr)', gap: 16, marginBottom: 24 }}>
           {[0,1,2,3].map(i => (
             <div key={i} style={{ background: 'var(--white)', border: '1px solid var(--gray3)', borderRadius: 16, padding: 20, display: 'flex', flexDirection: 'column', gap: 12 }}>
               {sk('60%', 11, 4)}{sk('75%', 28, 6)}{sk(80, 22, 100)}
@@ -1002,7 +1004,7 @@ export default function DashboardPage() {
           <div style={{ marginTop: 16 }}>{sk('100%', 90, 8)}</div>
         </div>
         {/* charts row */}
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 24 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr', gap: 16, marginBottom: 24 }}>
           {[0,1].map(i => (
             <div key={i} style={{ background: 'var(--white)', border: '1px solid var(--gray3)', borderRadius: 16, padding: 20, display: 'flex', flexDirection: 'column', gap: 12 }}>
               {sk(110, 11, 4)}{sk('100%', 160, 8)}
@@ -1039,7 +1041,7 @@ export default function DashboardPage() {
   return (
     <div>
       {/* Header */}
-      <div className="animate-slide-up delay-1" style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: 24, gap: 16 }}>
+      <div className="animate-slide-up delay-1" style={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: 24, gap: 16 }}>
         <div>
           <div style={{ fontSize: 22, fontWeight: 800, color: 'var(--black)', letterSpacing: '-0.02em' }}>
             Seja bem-vindo{firstName ? `, ${firstName}` : ''}! 👋
@@ -1054,7 +1056,7 @@ export default function DashboardPage() {
       </div>
 
       {/* KPI Cards */}
-      <div className="animate-slide-up delay-2" style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 14, marginBottom: 28 }}>
+      <div className="animate-slide-up delay-2" style={{ display: 'grid', gridTemplateColumns: isMobile ? 'repeat(2, 1fr)' : 'repeat(5, 1fr)', gap: 14, marginBottom: 28 }}>
         <SummaryCard
           label={isFiltered ? 'Leads no período' : 'Total de leads'}
           value={metrics.totalLeads ?? 0}
@@ -1147,7 +1149,7 @@ export default function DashboardPage() {
       )}
 
       {/* Charts row */}
-      <div className="animate-slide-up delay-4" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20, marginBottom: 24 }}>
+      <div className="animate-slide-up delay-4" style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr', gap: 20, marginBottom: 24 }}>
 
         {/* Donut: leads por status */}
         <div style={{ background: 'var(--white)', border: '1px solid var(--gray3)', borderRadius: 16, padding: 24, boxShadow: 'var(--shadow)' }}>
@@ -1166,7 +1168,7 @@ export default function DashboardPage() {
       </div>
 
       {/* Loss reasons + Rep status — side by side */}
-      <div className="animate-slide-up delay-5" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 20 }}>
+      <div className="animate-slide-up delay-5" style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr', gap: 16, marginBottom: 20 }}>
 
         {/* Motivos de perda */}
         <div style={{ background: 'var(--white)', border: '1px solid var(--gray3)', borderRadius: 16, padding: 24, boxShadow: 'var(--shadow)' }}>

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,5 +1,7 @@
 'use client'
+import { useEffect } from 'react'
 import { useSidebar } from '@/stores/sidebarStore'
+import { useIsMobile } from '@/lib/hooks/useMediaQuery'
 import { Topbar } from './Topbar'
 import { Sidebar } from './Sidebar'
 
@@ -13,7 +15,12 @@ interface Props {
 
 export function AppShell({ children, userName, userRole, brandName, logoUrl }: Props) {
   const { open, pinned, setOpen } = useSidebar()
-  const inGrid = open && pinned
+  const isMobile = useIsMobile()
+  const inGrid = open && pinned && !isMobile
+
+  useEffect(() => {
+    if (isMobile) setOpen(false)
+  }, [isMobile, setOpen])
 
   return (
     <div style={{
@@ -26,8 +33,8 @@ export function AppShell({ children, userName, userRole, brandName, logoUrl }: P
     }}>
       <Topbar userName={userName} userRole={userRole} brandName={brandName} logoUrl={logoUrl} />
 
-      {/* Backdrop for unpinned open sidebar */}
-      {open && !pinned && (
+      {/* Backdrop for overlay sidebar (unpinned or mobile) */}
+      {open && (!pinned || isMobile) && (
         <div
           onClick={() => setOpen(false)}
           style={{
@@ -40,7 +47,7 @@ export function AppShell({ children, userName, userRole, brandName, logoUrl }: P
 
       <Sidebar />
 
-      <main style={{ padding: '32px 36px', overflowY: 'auto', background: 'var(--bg)', minHeight: 0 }}>
+      <main style={{ padding: isMobile ? '16px 16px' : '32px 36px', overflowY: 'auto', background: 'var(--bg)', minHeight: 0 }}>
         {children}
       </main>
     </div>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation'
 import { LayoutGrid, BarChart3, Sparkles, Settings } from 'lucide-react'
 import { useSidebar } from '@/stores/sidebarStore'
 import { useModules } from '@/components/ModulesProvider'
+import { useIsMobile } from '@/lib/hooks/useMediaQuery'
 
 // ─── Nav structure ────────────────────────────────────────────────────────────
 
@@ -55,6 +56,8 @@ export function Sidebar() {
   const pathname = usePathname()
   const { open, pinned, setPinned, setOpen } = useSidebar()
   const modules = useModules()
+  const isMobile = useIsMobile()
+  const overlay = !pinned || isMobile
 
   function isItemVisible(href: string): boolean {
     if (href === '/settings')      return true
@@ -72,11 +75,11 @@ export function Sidebar() {
       display: 'flex',
       flexDirection: 'column',
       overflowX: 'hidden',
-      overflowY: pinned && !open ? 'hidden' : 'auto',
+      overflowY: !overlay && !open ? 'hidden' : 'auto',
       width: 220,
-      visibility: pinned && !open ? 'hidden' : 'visible',
-      // When unpinned: fixed overlay; when pinned: normal grid flow
-      ...(pinned ? {} : {
+      visibility: !overlay && !open ? 'hidden' : 'visible',
+      // overlay mode (unpinned or mobile): fixed drawer; normal mode: grid flow
+      ...(overlay ? {
         position: 'fixed',
         left: 0,
         top: 60,
@@ -85,7 +88,7 @@ export function Sidebar() {
         boxShadow: '4px 0 20px rgba(0,0,0,0.12)',
         transform: open ? 'translateX(0)' : 'translateX(-100%)',
         transition: 'transform 0.25s cubic-bezier(0.4,0,0.2,1)',
-      }),
+      } : {}),
     }}>
       {navItems.map((group) => {
         const visibleItems = group.items.filter(item => isItemVisible(item.href))
@@ -107,6 +110,7 @@ export function Sidebar() {
               <Link
                 key={item.href}
                 href={item.href}
+                onClick={() => { if (overlay) setOpen(false) }}
                 style={{
                   display: 'flex', alignItems: 'center', gap: 10,
                   padding: '9px 20px', fontSize: 13, fontWeight: 600,

--- a/components/widgets/DataTable.tsx
+++ b/components/widgets/DataTable.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState } from 'react'
+import { useIsMobile } from '@/lib/hooks/useMediaQuery'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -19,6 +20,9 @@ export interface DataTableProps {
   defaultSortDir?: 'asc' | 'desc'
   onRowClick?: (row: Record<string, unknown>) => void
   emptyMessage?: string
+  maxHeight?: number
+  /** Mobile rendering strategy. Defaults to 'cards'. Only affects < 768px. */
+  mobileMode?: 'cards' | 'scroll'
 }
 
 // ─── DataTable ────────────────────────────────────────────────────────────────
@@ -30,9 +34,12 @@ export function DataTable({
   defaultSortDir = 'desc',
   onRowClick,
   emptyMessage = 'Nenhum dado disponível',
+  maxHeight,
+  mobileMode = 'cards',
 }: DataTableProps) {
   const [sortCol, setSortCol] = useState<string>(defaultSortKey ?? columns[0]?.key ?? '')
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>(defaultSortDir)
+  const isMobile = useIsMobile()
 
   function handleSort(col: string) {
     if (sortCol === col) setSortDir(d => d === 'asc' ? 'desc' : 'asc')
@@ -51,63 +58,185 @@ export function DataTable({
     return sortDir === 'asc' ? cmp : -cmp
   })
 
+  // ── Shared table JSX (desktop + scroll-mode mobile) ───────────────────────
+
+  const thead = (
+    <thead>
+      <tr style={{ background: 'var(--bg)' }}>
+        {columns.map(col => {
+          const active = sortCol === col.key
+          const align = col.align ?? 'left'
+          return (
+            <th
+              key={col.key}
+              onClick={col.sortable !== false ? () => handleSort(col.key) : undefined}
+              style={{
+                padding: '9px 20px',
+                textAlign: align,
+                fontSize: 10, fontWeight: 800,
+                color: active ? 'var(--primary-text)' : 'var(--gray2)',
+                textTransform: 'uppercase', letterSpacing: '0.07em',
+                borderBottom: '1px solid var(--gray3)',
+                cursor: col.sortable !== false ? 'pointer' : 'default',
+                userSelect: 'none', transition: 'color .15s',
+                whiteSpace: 'nowrap',
+                ...(maxHeight ? { position: 'sticky', top: 0, background: 'var(--bg)', zIndex: 1 } : {}),
+              }}
+            >
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3, flexDirection: align === 'right' ? 'row-reverse' : 'row' }}>
+                {col.label}
+                {col.sortable !== false && (
+                  <span style={{ display: 'inline-flex', flexDirection: 'column', gap: 1, opacity: active ? 1 : 0.3, transition: 'opacity .15s' }}>
+                    <span style={{ fontSize: 7, lineHeight: 1, color: active && sortDir === 'asc' ? 'var(--primary-text)' : 'currentColor' }}>▲</span>
+                    <span style={{ fontSize: 7, lineHeight: 1, color: active && sortDir === 'desc' ? 'var(--primary-text)' : 'currentColor' }}>▼</span>
+                  </span>
+                )}
+              </span>
+            </th>
+          )
+        })}
+      </tr>
+    </thead>
+  )
+
+  const tbody = (
+    <tbody>
+      {sorted.length === 0 ? (
+        <tr>
+          <td colSpan={columns.length} style={{ padding: '32px 20px', textAlign: 'center', fontSize: 13, color: 'var(--gray2)' }}>
+            {emptyMessage}
+          </td>
+        </tr>
+      ) : (
+        sorted.map((row, i) => (
+          <DataTableRow
+            key={i}
+            row={row}
+            columns={columns}
+            index={i}
+            isLast={i === sorted.length - 1}
+            onClick={onRowClick}
+          />
+        ))
+      )}
+    </tbody>
+  )
+
+  // ── Mobile: cards ─────────────────────────────────────────────────────────
+
+  if (isMobile && mobileMode === 'cards') {
+    const sortableCols = columns.filter(c => c.sortable !== false)
+    const firstCol = columns[0]
+    const restCols = columns.slice(1)
+
+    return (
+      <div>
+        {/* Sort chips */}
+        {sortableCols.length > 0 && (
+          <div style={{
+            display: 'flex', gap: 6, overflowX: 'auto',
+            paddingBottom: 8, marginBottom: 12,
+          }}>
+            {sortableCols.map(col => {
+              const active = sortCol === col.key
+              return (
+                <button
+                  key={col.key}
+                  onClick={() => handleSort(col.key)}
+                  style={{
+                    flexShrink: 0, padding: '5px 10px', borderRadius: 100,
+                    fontSize: 11, fontWeight: 700, cursor: 'pointer',
+                    whiteSpace: 'nowrap', transition: 'all .15s',
+                    border: `1px solid ${active ? 'var(--primary)' : 'var(--gray3)'}`,
+                    background: active ? 'var(--primary-dim)' : 'var(--white)',
+                    color: active ? 'var(--primary-text)' : 'var(--gray)',
+                    display: 'inline-flex', alignItems: 'center', gap: 4,
+                    fontFamily: 'inherit',
+                  }}
+                >
+                  {col.label}
+                  {active && <span style={{ fontSize: 9 }}>{sortDir === 'asc' ? '▲' : '▼'}</span>}
+                </button>
+              )
+            })}
+          </div>
+        )}
+
+        {/* Empty state */}
+        {sorted.length === 0 ? (
+          <div style={{ padding: '32px 0', textAlign: 'center', fontSize: 13, color: 'var(--gray2)' }}>
+            {emptyMessage}
+          </div>
+        ) : sorted.map((row, i) => {
+          const firstVal = firstCol ? row[firstCol.key] : undefined
+          const firstDisplay = firstCol?.format
+            ? firstCol.format(firstVal)
+            : String(firstVal ?? '—')
+
+          return (
+            <div
+              key={i}
+              onClick={onRowClick ? () => onRowClick(row) : undefined}
+              style={{
+                background: 'var(--white)', border: '1px solid var(--gray3)',
+                borderRadius: 12, padding: 14, marginBottom: 10,
+                cursor: onRowClick ? 'pointer' : 'default',
+              }}
+            >
+              <div style={{ fontWeight: 800, fontSize: 15, color: 'var(--black)', marginBottom: restCols.length ? 10 : 0 }}>
+                {firstDisplay}
+              </div>
+
+              {restCols.map(col => {
+                const value = row[col.key]
+                const display = col.format ? col.format(value) : String(value ?? '—')
+                return (
+                  <div
+                    key={col.key}
+                    style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', paddingTop: 6 }}
+                  >
+                    <span style={{ fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.07em', color: 'var(--gray2)' }}>
+                      {col.label}
+                    </span>
+                    <span style={{ fontSize: 13, fontWeight: col.align === 'right' ? 800 : 600, color: col.align === 'right' ? 'var(--green)' : 'var(--black)' }}>
+                      {display}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          )
+        })}
+      </div>
+    )
+  }
+
+  // ── Mobile: scroll ────────────────────────────────────────────────────────
+
+  if (isMobile && mobileMode === 'scroll') {
+    const inner = maxHeight
+      ? <div style={{ maxHeight, overflowY: 'auto', borderRadius: 8 }}><table style={{ width: '100%', borderCollapse: 'collapse' }}>{thead}{tbody}</table></div>
+      : <table style={{ width: '100%', borderCollapse: 'collapse' }}>{thead}{tbody}</table>
+    return <div style={{ overflowX: 'auto' }}>{inner}</div>
+  }
+
+  // ── Desktop: original table ───────────────────────────────────────────────
+
+  if (maxHeight) {
+    return (
+      <div style={{ maxHeight, overflowY: 'auto', borderRadius: 8 }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          {thead}
+          {tbody}
+        </table>
+      </div>
+    )
+  }
+
   return (
     <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-      <thead>
-        <tr style={{ background: 'var(--bg)' }}>
-          {columns.map(col => {
-            const active = sortCol === col.key
-            const align = col.align ?? 'left'
-            return (
-              <th
-                key={col.key}
-                onClick={col.sortable !== false ? () => handleSort(col.key) : undefined}
-                style={{
-                  padding: '9px 20px',
-                  textAlign: align,
-                  fontSize: 10, fontWeight: 800,
-                  color: active ? 'var(--primary-text)' : 'var(--gray2)',
-                  textTransform: 'uppercase', letterSpacing: '0.07em',
-                  borderBottom: '1px solid var(--gray3)',
-                  cursor: col.sortable !== false ? 'pointer' : 'default',
-                  userSelect: 'none', transition: 'color .15s',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3, flexDirection: align === 'right' ? 'row-reverse' : 'row' }}>
-                  {col.label}
-                  {col.sortable !== false && (
-                    <span style={{ display: 'inline-flex', flexDirection: 'column', gap: 1, opacity: active ? 1 : 0.3, transition: 'opacity .15s' }}>
-                      <span style={{ fontSize: 7, lineHeight: 1, color: active && sortDir === 'asc' ? 'var(--primary-text)' : 'currentColor' }}>▲</span>
-                      <span style={{ fontSize: 7, lineHeight: 1, color: active && sortDir === 'desc' ? 'var(--primary-text)' : 'currentColor' }}>▼</span>
-                    </span>
-                  )}
-                </span>
-              </th>
-            )
-          })}
-        </tr>
-      </thead>
-      <tbody>
-        {sorted.length === 0 ? (
-          <tr>
-            <td colSpan={columns.length} style={{ padding: '32px 20px', textAlign: 'center', fontSize: 13, color: 'var(--gray2)' }}>
-              {emptyMessage}
-            </td>
-          </tr>
-        ) : (
-          sorted.map((row, i) => (
-            <DataTableRow
-              key={i}
-              row={row}
-              columns={columns}
-              index={i}
-              isLast={i === sorted.length - 1}
-              onClick={onRowClick}
-            />
-          ))
-        )}
-      </tbody>
+      {thead}
+      {tbody}
     </table>
   )
 }

--- a/lib/hooks/useMediaQuery.ts
+++ b/lib/hooks/useMediaQuery.ts
@@ -1,0 +1,29 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export const BREAKPOINTS = { mobile: 768, tablet: 1024 } as const
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false)
+
+  useEffect(() => {
+    const mql = window.matchMedia(query)
+    setMatches(mql.matches)
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches)
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [query])
+
+  return matches
+}
+
+export function useIsMobile(): boolean {
+  return useMediaQuery(`(max-width: ${BREAKPOINTS.mobile - 1}px)`)
+}
+
+export function useIsTablet(): boolean {
+  return useMediaQuery(
+    `(min-width: ${BREAKPOINTS.mobile}px) and (max-width: ${BREAKPOINTS.tablet - 1}px)`
+  )
+}


### PR DESCRIPTION
Porta padrões de responsividade do Anupana (fork gêmeo):
- lib/hooks/useMediaQuery: useIsMobile/useIsTablet (bp 768)
- DataTable: modo mobile em cartões/scroll abaixo de 768px
- dashboard: grids responsivos (KPIs 5->2 col, gráficos e header empilham)
- AppShell/Sidebar: drawer mobile (overlay + backdrop + auto-close), preservando o nav próprio do Mult10