### PR TITLE
chore: corrige vulnerabilidade high do ws (npm audit fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3151,7 +3151,6 @@
       "version": "8.5.12",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
       "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4124,9 +4123,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Resumo
`npm audit fix` (não-breaking) corrigindo a vulnerabilidade **high** `ws` (memory exhaustion DoS via fragmentos), bump transitivo no `package-lock.json` (package.json inalterado).

### Notas
- A low restante (`esbuild` — leitura de arquivo arbitrária no dev server, **somente Windows/dev**) foi **deixada de fora** porque o fix exige `--force` (bump major do `tsx`, breaking). Não afeta produção.
- A discrepância com o Dependabot (15 alertas) é contagem por caminho/advisory; o `npm audit` local resolvia 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)