### PR TITLE
feat: popula 'sessões recentes' do SDR por chatId

### DIFF
--- a/app/(app)/sdr-ia/dashboard/page.tsx
+++ b/app/(app)/sdr-ia/dashboard/page.tsx
@@ -128,12 +128,6 @@ const TABLE_COLS: DataTableColumn[] = [
     ),
   },
   { key: 'msgs', label: 'Mensagens', sortable: true },
-  {
-    key: 'lastContact',
-    label: 'Última interação',
-    sortable: true,
-    format: (v) => timeAgo(v as number | null),
-  },
 ]
 
 // ─── Empty state ──────────────────────────────────────────────────────────────
@@ -222,7 +216,6 @@ export default function SdrIaDashboardPage() {
   const tableRows = (data?.recent ?? []).map(r => ({
     sessionLabel: r.sessionId,
     msgs:         r.msgs,
-    lastContact:  r.lastContact ?? 0,
   }))
 
   const hasData = (data?.funnel.length ?? 0) > 0 || (data?.recent.length ?? 0) > 0
@@ -364,7 +357,7 @@ export default function SdrIaDashboardPage() {
               <DataTable
                 columns={TABLE_COLS}
                 rows={tableRows}
-                defaultSortKey="lastContact"
+                defaultSortKey="msgs"
                 defaultSortDir="desc"
                 emptyMessage="Nenhuma sessão encontrada no período"
               />

--- a/app/api/bi/sdr/route.ts
+++ b/app/api/bi/sdr/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
 import { db } from '@/lib/db'
 import { events, conversations, funnelSnapshots, dataSources } from '@/lib/db/schema'
-import { and, desc, eq, gte, lte, sql } from 'drizzle-orm'
+import { and, eq, gte, lte, sql } from 'drizzle-orm'
 import { assertEntitlement } from '@/lib/entitlements'
 
 const DAY = 86_400_000
@@ -64,19 +64,20 @@ export async function GET(request: Request) {
     ))
     .groupBy(events.sentiment)
 
-  // ── Conversations: recent sessions (last 2000 rows, deduplicated in JS) ──
+  // ── Conversations: recent sessions ──────────────────────────────────────
+  // n8n_chat_histories não tem timestamp; usamos o chatId (id sequencial,
+  // guardado em metadata) como proxy de recência. Sem filtro por período.
   const convRows = await db
     .select({
-      sessionId:  conversations.sessionId,
-      occurredAt: conversations.occurredAt,
+      sessionId: conversations.sessionId,
+      chatId:    sql<number>`json_extract(${conversations.metadata}, '$.chatId')`,
     })
     .from(conversations)
     .where(and(
       eq(conversations.tenantId, tenantId),
       eq(conversations.source, 'supabase-n8n'),
-      gte(conversations.occurredAt, periodStart),
     ))
-    .orderBy(desc(conversations.occurredAt))
+    .orderBy(sql`json_extract(${conversations.metadata}, '$.chatId') desc`)
     .limit(2000)
 
   // ── Data source for lastSyncAt ───────────────────────────────────────────
@@ -114,22 +115,22 @@ export async function GET(request: Request) {
     { id: 'unknown',  label: 'Sem análise', color: '#AAAAAA', count: sentMap.get('unknown')  ?? 0 },
   ].filter(s => s.count > 0)
 
-  // ── Dedup conversations by sessionId ────────────────────────────────────
-  const sessionMap = new Map<string, { lastContact: number | null; msgs: number }>()
+  // ── Dedup por sessionId; recência = maior chatId da sessão ──────────────
+  const sessionMap = new Map<string, { maxChatId: number; msgs: number }>()
   for (const row of convRows) {
-    const ms = row.occurredAt instanceof Date ? row.occurredAt.getTime() : null
+    const cid = Number(row.chatId) || 0
     const ex = sessionMap.get(row.sessionId)
     if (!ex) {
-      sessionMap.set(row.sessionId, { lastContact: ms, msgs: 1 })
+      sessionMap.set(row.sessionId, { maxChatId: cid, msgs: 1 })
     } else {
       ex.msgs++
-      if (ms && (!ex.lastContact || ms > ex.lastContact)) ex.lastContact = ms
+      if (cid > ex.maxChatId) ex.maxChatId = cid
     }
   }
   const recent = Array.from(sessionMap.entries())
-    .sort((a, b) => (b[1].lastContact ?? 0) - (a[1].lastContact ?? 0))
+    .sort((a, b) => b[1].maxChatId - a[1].maxChatId)
     .slice(0, 50)
-    .map(([sessionId, { lastContact, msgs }]) => ({ sessionId, lastContact, msgs }))
+    .map(([sessionId, { msgs }]) => ({ sessionId, msgs, lastContact: null as number | null }))
 
   const lastSyncAtMs = ds?.lastSyncAt instanceof Date
     ? ds.lastSyncAt.getTime()

--- a/lib/providers/supabase-n8n.ts
+++ b/lib/providers/supabase-n8n.ts
@@ -219,6 +219,9 @@ export const supabaseN8nProvider: DataSourceProvider<Config, SupabaseN8nRaw> = {
       sessionId: row.session_id,
       role: row.message?.type === 'ai' ? 'ai' : 'human',
       content: row.message?.content ?? '',
+      // n8n_chat_histories não tem coluna de timestamp; guardamos o id sequencial
+      // do chat como proxy de recência para ordenar as "sessões recentes".
+      metadata: { chatId: typeof row.id === 'number' ? row.id : Number(row.id) || 0 },
     }))
 
     return { funnel, events, conversations }


### PR DESCRIPTION
## Resumo
Faz a tabela "Sessões recentes" do dashboard SDR IA finalmente popular.

### Contexto
A origem (`n8n_chat_histories`) **não tem coluna de timestamp** — só `id, session_id, message`. Por isso as conversas eram gravadas com `occurred_at = NULL` e o dashboard (que filtrava/ordenava por tempo) deixava a tabela vazia.

### Mudanças (opção "a" — recência por id sequencial)
- **provider**: guarda o id sequencial do chat em `conversations.metadata.chatId` (proxy de recência). (lib/providers/supabase-n8n.ts)
- **API /api/bi/sdr**: ordena as sessões por `json_extract(metadata,'$.chatId')` em vez de `occurred_at`; sem filtro por período (não há tempo real). (app/api/bi/sdr/route.ts)
- **dashboard**: remove a coluna "Última interação" (sem timestamp real) e ordena por nº de mensagens. (app/(app)/sdr-ia/dashboard/page.tsx)

### Limitação conhecida
Sem timestamp na origem, "Sessões recentes" é **independente do filtro de período**. O fix definitivo seria adicionar um `created_at` ao `n8n_chat_histories` no fluxo do n8n.

### Validação
- Type-check (npx tsc --noEmit) limpo.
- Re-sync do tenant 300: `metadata.chatId` populado; query retorna 108 sessões → top 50 por recência com contagem de mensagens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)