### PR TITLE
feat: integração YCloud (WhatsApp Business API)

### DIFF
--- a/app/(app)/sdr-ia/contatos/page.tsx
+++ b/app/(app)/sdr-ia/contatos/page.tsx
@@ -1,0 +1,266 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { Search } from 'lucide-react'
+import { DataTable } from '@/components/widgets/DataTable'
+import type { DataTableColumn } from '@/components/widgets/DataTable'
+import { timeAgo } from '@/lib/format'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface ContactItem {
+  id: string
+  name: string | null
+  phone: string | null
+  email: string | null
+  tags: string[]
+  lastInteractionAt: number | null
+  createdAt: number | null
+}
+
+interface ApiResponse {
+  items: ContactItem[]
+  total: number
+  page: number
+  limit: number
+}
+
+// ─── Table columns ────────────────────────────────────────────────────────────
+
+const LIMIT = 50
+
+const COLS: DataTableColumn[] = [
+  {
+    key: 'name',
+    label: 'Nome',
+    sortable: false,
+    format: (v) => (
+      <span style={{ fontWeight: 700, color: 'var(--black)' }}>
+        {(v as string | null) || '—'}
+      </span>
+    ),
+  },
+  {
+    key: 'phone',
+    label: 'Telefone',
+    sortable: false,
+    format: (v) => (
+      <span style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--gray)' }}>
+        {(v as string | null) || '—'}
+      </span>
+    ),
+  },
+  {
+    key: 'lastInteractionAt',
+    label: 'Última interação',
+    sortable: true,
+    format: (v) => (
+      <span style={{ color: 'var(--gray)', fontSize: 12, fontWeight: 500 }}>
+        {timeAgo(v as number | null)}
+      </span>
+    ),
+  },
+  {
+    key: 'tags',
+    label: 'Tags',
+    sortable: false,
+    format: (v) => {
+      const tags = v as string[]
+      if (!tags?.length) return <span style={{ color: 'var(--gray3)', fontSize: 11 }}>—</span>
+      return (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+          {tags.map(tag => (
+            <span key={tag} style={{
+              fontSize: 10, fontWeight: 700,
+              padding: '2px 7px', borderRadius: 99,
+              background: 'rgba(37,211,102,0.08)',
+              color: '#15803d',
+              border: '1px solid rgba(37,211,102,0.20)',
+            }}>
+              {tag}
+            </span>
+          ))}
+        </div>
+      )
+    },
+  },
+]
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function ContatosPage() {
+  const [data,    setData]    = useState<ApiResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error,   setError]   = useState(false)
+  const [page,    setPage]    = useState(1)
+  const [q,       setQ]       = useState('')
+  const [debQ,    setDebQ]    = useState('')
+
+  // Debounce search input by 300 ms
+  useEffect(() => {
+    const t = setTimeout(() => setDebQ(q), 300)
+    return () => clearTimeout(t)
+  }, [q])
+
+  // Reset to first page when search changes
+  useEffect(() => { setPage(1) }, [debQ])
+
+  // Fetch contacts
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(false)
+
+    const params = new URLSearchParams({ page: String(page), limit: String(LIMIT) })
+    if (debQ) params.set('q', debQ)
+
+    fetch(`/api/contacts?${params}`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.status))
+      .then((d: ApiResponse) => { if (!cancelled) { setData(d); setLoading(false) } })
+      .catch(() => { if (!cancelled) { setError(true); setLoading(false) } })
+
+    return () => { cancelled = true }
+  }, [page, debQ])
+
+  const total      = data?.total ?? 0
+  const totalPages = Math.max(1, Math.ceil(total / LIMIT))
+  const hasPrev    = page > 1
+  const hasNext    = page < totalPages
+
+  const tableRows = (data?.items ?? []).map(c => ({
+    id:                c.id,
+    name:              c.name,
+    phone:             c.phone,
+    tags:              c.tags,
+    lastInteractionAt: c.lastInteractionAt ?? 0,
+  }))
+
+  return (
+    <div>
+
+      {/* ── Header + search ────────────────────────────────────────── */}
+      <div className="animate-slide-up delay-1" style={{
+        display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between',
+        flexWrap: 'wrap', gap: 16, marginBottom: 24,
+      }}>
+        <div>
+          <div style={{ fontSize: 22, fontWeight: 800, color: 'var(--black)', letterSpacing: '-0.02em', marginBottom: 4 }}>
+            Contatos WhatsApp
+          </div>
+          <div style={{ fontSize: 13, color: 'var(--gray)' }}>
+            Contatos sincronizados via YCloud — REST backfill e webhooks.
+          </div>
+        </div>
+
+        <div style={{ position: 'relative' }}>
+          <Search
+            size={14}
+            style={{
+              position: 'absolute', left: 12, top: '50%',
+              transform: 'translateY(-50%)',
+              color: 'var(--gray2)', pointerEvents: 'none',
+            }}
+          />
+          <input
+            value={q}
+            onChange={e => setQ(e.target.value)}
+            placeholder="Nome ou telefone..."
+            style={{
+              paddingLeft: 34, paddingRight: 14, paddingTop: 9, paddingBottom: 9,
+              fontSize: 13, fontFamily: 'inherit', fontWeight: 500,
+              border: '1px solid var(--gray3)', borderRadius: 99,
+              background: 'var(--white)', color: 'var(--black)',
+              outline: 'none', transition: 'border-color .15s', minWidth: 220,
+            }}
+            onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+            onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+          />
+        </div>
+      </div>
+
+      {/* ── Status line ────────────────────────────────────────────── */}
+      {!loading && !error && data && (
+        <div style={{ fontSize: 12, color: 'var(--gray2)', fontWeight: 500, marginBottom: 16 }}>
+          {total.toLocaleString('pt-BR')} contato{total !== 1 ? 's' : ''}
+          {debQ && ` para "${debQ}"`}
+          {totalPages > 1 && ` — página ${page} de ${totalPages}`}
+        </div>
+      )}
+
+      {/* ── Loading ────────────────────────────────────────────────── */}
+      {loading && (
+        <div style={{ padding: '48px 0', textAlign: 'center', fontSize: 13, color: 'var(--gray2)' }}>
+          Carregando...
+        </div>
+      )}
+
+      {/* ── Error ──────────────────────────────────────────────────── */}
+      {!loading && error && (
+        <div style={{ padding: '48px 0', textAlign: 'center' }}>
+          <div style={{ fontSize: 14, fontWeight: 700, color: '#D93025', marginBottom: 8 }}>
+            Falha ao carregar contatos
+          </div>
+          <div style={{ fontSize: 13, color: 'var(--gray2)' }}>
+            Verifique se o módulo YCloud está ativo e tente novamente.
+          </div>
+        </div>
+      )}
+
+      {/* ── Table ──────────────────────────────────────────────────── */}
+      {!loading && !error && (
+        <div className="animate-slide-up delay-2" style={{
+          background: 'var(--white)', borderRadius: 16,
+          border: '1px solid var(--gray3)', overflow: 'hidden',
+        }}>
+          <DataTable
+            columns={COLS}
+            rows={tableRows}
+            defaultSortKey="lastInteractionAt"
+            defaultSortDir="desc"
+            emptyMessage={
+              debQ
+                ? `Nenhum contato encontrado para "${debQ}"`
+                : 'Nenhum contato sincronizado ainda'
+            }
+          />
+        </div>
+      )}
+
+      {/* ── Pagination ─────────────────────────────────────────────── */}
+      {!loading && !error && totalPages > 1 && (
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 12, marginTop: 20 }}>
+          <button
+            onClick={() => setPage(p => p - 1)}
+            disabled={!hasPrev}
+            style={{
+              padding: '8px 18px', borderRadius: 99, fontFamily: 'inherit',
+              fontSize: 13, fontWeight: 700,
+              cursor: hasPrev ? 'pointer' : 'not-allowed',
+              border: '1px solid var(--gray3)', background: 'var(--white)',
+              color: hasPrev ? 'var(--black)' : 'var(--gray3)',
+              transition: 'all .15s',
+            }}
+          >
+            ← Anterior
+          </button>
+          <span style={{ fontSize: 12, color: 'var(--gray2)', fontWeight: 500 }}>
+            {page} / {totalPages}
+          </span>
+          <button
+            onClick={() => setPage(p => p + 1)}
+            disabled={!hasNext}
+            style={{
+              padding: '8px 18px', borderRadius: 99, fontFamily: 'inherit',
+              fontSize: 13, fontWeight: 700,
+              cursor: hasNext ? 'pointer' : 'not-allowed',
+              border: '1px solid var(--gray3)', background: 'var(--white)',
+              color: hasNext ? 'var(--black)' : 'var(--gray3)',
+              transition: 'all .15s',
+            }}
+          >
+            Próxima →
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/(app)/sdr-ia/conversas/page.tsx
+++ b/app/(app)/sdr-ia/conversas/page.tsx
@@ -1,0 +1,586 @@
+'use client'
+import { useEffect, useRef, useState } from 'react'
+import type { CSSProperties } from 'react'
+import { timeAgo } from '@/lib/format'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface SessionItem {
+  sessionId:   string
+  name:        string | null
+  phone:       string
+  lastContact: number | null
+  msgs:        number
+  lastMessage: { content: string; role: string }
+}
+
+interface Message {
+  id:         string
+  role:       'human' | 'ai' | 'system'
+  content:    string
+  occurredAt: number | null
+  metadata:   Record<string, unknown>
+}
+
+interface Thread {
+  sessionId:      string
+  contact:        { name: string | null; phone: string }
+  inWindow:       boolean
+  windowExpiresAt: number | null
+  messages:       Message[]
+}
+
+interface WaTemplate {
+  name:       string
+  language:   string
+  category?:  string
+  status:     string
+  components?: unknown[]
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function countVars(tpl: WaTemplate): number {
+  if (!tpl.components) return 0
+  const body = (tpl.components as Array<Record<string, unknown>>)
+    .find(c => String(c.type).toUpperCase() === 'BODY')
+  if (!body || typeof body.text !== 'string') return 0
+  return (body.text.match(/\{\{\d+\}\}/g) ?? []).length
+}
+
+function buildComponents(values: string[]): object[] {
+  if (!values.length) return []
+  return [{ type: 'body', parameters: values.map(text => ({ type: 'text', text })) }]
+}
+
+function pagerStyle(enabled: boolean): CSSProperties {
+  return {
+    fontSize: 11, fontWeight: 700, padding: '4px 10px', borderRadius: 99,
+    border: '1px solid var(--gray3)', background: 'transparent',
+    cursor: enabled ? 'pointer' : 'not-allowed',
+    color: enabled ? 'var(--black)' : 'var(--gray3)',
+    fontFamily: 'inherit',
+  }
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function Bubble({ msg }: { msg: Message }) {
+  const isHuman = msg.role === 'human'
+  return (
+    <div style={{ display: 'flex', justifyContent: isHuman ? 'flex-start' : 'flex-end' }}>
+      <div style={{
+        maxWidth: '72%', padding: '8px 12px', wordBreak: 'break-word',
+        borderRadius: isHuman ? '4px 12px 12px 12px' : '12px 4px 12px 12px',
+        background: isHuman ? 'var(--bg)' : 'var(--primary)',
+        border: isHuman ? '1px solid var(--gray3)' : 'none',
+        color: isHuman ? 'var(--black)' : '#fff',
+        fontSize: 13, lineHeight: 1.5,
+      }}>
+        <div style={{ marginBottom: 3 }}>{msg.content}</div>
+        <div style={{ fontSize: 10, opacity: 0.55, textAlign: isHuman ? 'left' : 'right' }}>
+          {timeAgo(msg.occurredAt)}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface SendBtnProps { label: string; disabled: boolean; loading: boolean; onClick: () => void }
+function SendBtn({ label, disabled, loading, onClick }: SendBtnProps) {
+  return (
+    <button onClick={onClick} disabled={disabled} style={{
+      padding: '9px 20px', borderRadius: 12, border: 'none',
+      fontFamily: 'inherit', fontSize: 13, fontWeight: 700,
+      cursor: disabled ? 'not-allowed' : 'pointer', flexShrink: 0,
+      background: disabled ? 'var(--gray3)' : 'var(--primary)',
+      color: disabled ? 'var(--gray2)' : '#fff',
+      transition: 'background .15s',
+    }}>
+      {loading ? 'Enviando...' : label}
+    </button>
+  )
+}
+
+interface TplComposerProps {
+  templates:       WaTemplate[] | null
+  loading:         boolean
+  selected:        WaTemplate | null
+  vars:            string[]
+  windowExpiresAt: number | null
+  sending:         boolean
+  onSelect:        (tpl: WaTemplate) => void
+  onVarChange:     (i: number, v: string) => void
+  onSend:          () => void
+}
+function TemplateComposer({
+  templates, loading, selected, vars, windowExpiresAt, sending, onSelect, onVarChange, onSend,
+}: TplComposerProps) {
+  const expiredAgo = windowExpiresAt ? timeAgo(windowExpiresAt) : null
+  return (
+    <div>
+      <div style={{
+        marginBottom: 10, padding: '8px 12px', borderRadius: 8, fontSize: 12, fontWeight: 600,
+        background: 'rgba(217,150,0,0.06)', border: '1px solid rgba(217,150,0,0.25)', color: '#92650a',
+      }}>
+        {expiredAgo
+          ? `Janela de 24h expirada há ${expiredAgo} — envie um template aprovado`
+          : 'Nenhuma mensagem recebida ainda — inicie com um template aprovado'}
+      </div>
+
+      {loading && (
+        <p style={{ fontSize: 12, color: 'var(--gray2)', margin: 0 }}>Carregando templates...</p>
+      )}
+
+      {!loading && templates !== null && (
+        templates.length === 0 ? (
+          <p style={{ fontSize: 12, color: 'var(--gray2)', margin: 0 }}>
+            Nenhum template aprovado disponível nesta conta.
+          </p>
+        ) : (
+          <>
+            <select
+              value={selected?.name ?? ''}
+              onChange={e => {
+                const t = templates.find(x => x.name === e.target.value)
+                if (t) onSelect(t)
+              }}
+              style={{
+                width: '100%', fontFamily: 'inherit', fontSize: 13,
+                padding: '8px 12px', marginBottom: 8,
+                border: '1px solid var(--gray3)', borderRadius: 8,
+                background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+              }}
+            >
+              <option value="">Selecionar template...</option>
+              {templates.map(t => (
+                <option key={`${t.name}:${t.language}`} value={t.name}>
+                  {t.name} ({t.language}){t.category ? ` · ${t.category}` : ''}
+                </option>
+              ))}
+            </select>
+
+            {selected && vars.length > 0 && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 8 }}>
+                {vars.map((v, i) => (
+                  <input
+                    key={i}
+                    value={v}
+                    onChange={e => onVarChange(i, e.target.value)}
+                    placeholder={`Variável {{${i + 1}}}`}
+                    style={{
+                      fontFamily: 'inherit', fontSize: 13, padding: '7px 12px',
+                      border: '1px solid var(--gray3)', borderRadius: 8,
+                      background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+                    }}
+                  />
+                ))}
+              </div>
+            )}
+
+            {selected && (
+              <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                <SendBtn
+                  label="Enviar template"
+                  disabled={sending || vars.some(v => !v.trim())}
+                  loading={sending}
+                  onClick={onSend}
+                />
+              </div>
+            )}
+          </>
+        )
+      )}
+    </div>
+  )
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+const SESSION_LIMIT = 20
+
+export default function ConversasPage() {
+  // Session list
+  const [sessions,    setSessions]    = useState<SessionItem[]>([])
+  const [sessTotal,   setSessTotal]   = useState(0)
+  const [sessPage,    setSessPage]    = useState(1)
+  const [sessLoading, setSessLoading] = useState(true)
+  const [sessError,   setSessError]   = useState(false)
+
+  // Active thread
+  const [activeId,      setActiveId]      = useState<string | null>(null)
+  const [thread,        setThread]        = useState<Thread | null>(null)
+  const [threadLoading, setThreadLoading] = useState(false)
+
+  // Templates — per-tenant, cached across threads
+  const [templates,  setTemplates]  = useState<WaTemplate[] | null>(null)
+  const [tplLoading, setTplLoading] = useState(false)
+  const [tplLoaded,  setTplLoaded]  = useState(false)
+
+  // Composer
+  const [textBody,    setTextBody]    = useState('')
+  const [selTemplate, setSelTemplate] = useState<WaTemplate | null>(null)
+  const [tplVars,     setTplVars]     = useState<string[]>([])
+  const [sending,     setSending]     = useState(false)
+  const [sendError,   setSendError]   = useState<string | null>(null)
+
+  const bottomRef  = useRef<HTMLDivElement>(null)
+  // Stale-fetch guard: ensures a slow earlier fetch can't overwrite a later thread
+  const fetchIdRef = useRef(0)
+
+  // ── Fetch session list ──────────────────────────────────────────────────────
+  useEffect(() => {
+    setSessLoading(true)
+    setSessError(false)
+    fetch(`/api/ycloud/conversations?page=${sessPage}&limit=${SESSION_LIMIT}`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.status))
+      .then((d: { items: SessionItem[]; total: number }) => {
+        setSessions(d.items)
+        setSessTotal(d.total)
+      })
+      .catch(() => setSessError(true))
+      .finally(() => setSessLoading(false))
+  }, [sessPage])
+
+  // ── Auto-scroll to bottom whenever thread (or its messages) changes ─────────
+  useEffect(() => {
+    if (thread) bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [thread])
+
+  // ── Lazy-load templates when window is closed ───────────────────────────────
+  useEffect(() => {
+    if (thread && !thread.inWindow && !tplLoaded && !tplLoading) {
+      setTplLoading(true)
+      fetch('/api/ycloud/templates')
+        .then(r => r.ok ? r.json() : Promise.reject(r.status))
+        .then((d: { templates: WaTemplate[] }) =>
+          setTemplates(d.templates.filter(t => t.status === 'approved'))
+        )
+        .catch(() => setTemplates([]))
+        .finally(() => { setTplLoading(false); setTplLoaded(true) })
+    }
+  }, [thread, tplLoaded, tplLoading])
+
+  // ── Open a session ──────────────────────────────────────────────────────────
+  function loadThread(sessionId: string) {
+    const fetchId = ++fetchIdRef.current
+    setActiveId(sessionId)
+    setThread(null)
+    setThreadLoading(true)
+    setSendError(null)
+    setTextBody('')
+    setSelTemplate(null)
+    setTplVars([])
+    fetch(`/api/ycloud/conversations/${encodeURIComponent(sessionId)}`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.status))
+      .then((d: Thread) => { if (fetchIdRef.current === fetchId) setThread(d) })
+      .catch(() => {})
+      .finally(() => { if (fetchIdRef.current === fetchId) setThreadLoading(false) })
+  }
+
+  // ── Send ────────────────────────────────────────────────────────────────────
+  async function send() {
+    if (!activeId || !thread || sending) return
+    setSendError(null)
+
+    let reqBody: object
+    let preview: string
+
+    if (thread.inWindow) {
+      if (!textBody.trim()) return
+      reqBody = { to: activeId, type: 'text', body: textBody.trim() }
+      preview = textBody.trim()
+    } else {
+      if (!selTemplate || tplVars.some(v => !v.trim())) return
+      reqBody = {
+        to:           activeId,
+        type:         'template',
+        templateName: selTemplate.name,
+        languageCode: selTemplate.language,
+        components:   buildComponents(tplVars.map(v => v.trim())),
+      }
+      preview = `[template:${selTemplate.name}]`
+    }
+
+    setSending(true)
+    try {
+      const res  = await fetch('/api/ycloud/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(reqBody),
+      })
+      const data = await res.json() as Record<string, unknown>
+
+      if (!res.ok) {
+        if (data.error === 'fora_da_janela_24h') {
+          loadThread(activeId)   // refresh inWindow flag
+          setSendError('Janela de 24h expirada — selecione um template.')
+        } else {
+          setSendError(typeof data.message === 'string' ? data.message : `Erro ${res.status}`)
+        }
+        return
+      }
+
+      // Optimistic append of the sent message
+      setThread(prev => prev ? {
+        ...prev,
+        messages: [...prev.messages, {
+          id:         `opt:${Date.now()}`,
+          role:       'ai' as const,
+          content:    preview,
+          occurredAt: Date.now(),
+          metadata:   {},
+        }],
+      } : prev)
+      setTextBody('')
+      setSelTemplate(null)
+      setTplVars([])
+    } catch {
+      setSendError('Erro de rede')
+    } finally {
+      setSending(false)
+    }
+  }
+
+  function selectTemplate(tpl: WaTemplate) {
+    setSelTemplate(tpl)
+    setTplVars(Array<string>(countVars(tpl)).fill(''))
+  }
+
+  const totalPages = Math.ceil(sessTotal / SESSION_LIMIT)
+
+  // ─── Render ─────────────────────────────────────────────────────────────────
+
+  return (
+    <div style={{
+      display: 'flex', height: 'calc(100vh - 160px)', minHeight: 420,
+      border: '1px solid var(--gray3)', borderRadius: 16, overflow: 'hidden',
+      background: '#fff',
+    }}>
+
+      {/* ── LEFT: session list ─────────────────────────────────────────────── */}
+      <div style={{
+        width: 280, flexShrink: 0, borderRight: '1px solid var(--gray3)',
+        display: 'flex', flexDirection: 'column',
+      }}>
+        <div style={{
+          padding: '12px 16px', borderBottom: '1px solid var(--gray3)',
+          fontSize: 11, fontWeight: 800, textTransform: 'uppercase',
+          letterSpacing: '0.08em', color: 'var(--gray2)',
+        }}>
+          WhatsApp
+        </div>
+
+        <div style={{ flex: 1, overflowY: 'auto' }}>
+          {sessLoading && (
+            <p style={{ padding: '20px 16px', fontSize: 12, color: 'var(--gray2)', margin: 0 }}>
+              Carregando...
+            </p>
+          )}
+          {sessError && (
+            <p style={{ padding: '20px 16px', fontSize: 12, color: '#c0392b', margin: 0 }}>
+              Falha ao carregar conversas
+            </p>
+          )}
+          {!sessLoading && !sessError && sessions.length === 0 && (
+            <p style={{ padding: '20px 16px', fontSize: 12, color: 'var(--gray2)', margin: 0 }}>
+              Nenhuma conversa ainda
+            </p>
+          )}
+          {sessions.map(s => {
+            const isActive = s.sessionId === activeId
+            return (
+              <button
+                key={s.sessionId}
+                onClick={() => loadThread(s.sessionId)}
+                style={{
+                  display: 'block', width: '100%', textAlign: 'left',
+                  padding: '11px 14px', background: isActive ? 'rgba(0,0,0,0.04)' : 'transparent',
+                  border: 'none', borderBottom: '1px solid var(--gray3)',
+                  borderLeft: `3px solid ${isActive ? 'var(--primary)' : 'transparent'}`,
+                  cursor: 'pointer', fontFamily: 'inherit',
+                }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, marginBottom: 2 }}>
+                  <span style={{
+                    fontSize: 13, fontWeight: 700, color: 'var(--black)',
+                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1,
+                  }}>
+                    {s.name ?? s.phone}
+                  </span>
+                  <span style={{ fontSize: 10, color: 'var(--gray2)', fontWeight: 500, flexShrink: 0 }}>
+                    {timeAgo(s.lastContact)}
+                  </span>
+                </div>
+                <div style={{
+                  fontSize: 11, color: 'var(--gray)',
+                  overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                }}>
+                  {s.lastMessage.role !== 'human' && '↗ '}
+                  {s.lastMessage.content}
+                </div>
+                <div style={{ fontSize: 10, color: 'var(--gray2)', marginTop: 2 }}>
+                  {s.msgs} msg{s.msgs !== 1 ? 's' : ''}
+                </div>
+              </button>
+            )
+          })}
+        </div>
+
+        {totalPages > 1 && (
+          <div style={{
+            padding: '8px 10px', borderTop: '1px solid var(--gray3)',
+            display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 6,
+          }}>
+            <button
+              onClick={() => setSessPage(p => p - 1)}
+              disabled={sessPage <= 1}
+              style={pagerStyle(sessPage > 1)}
+            >← Ant</button>
+            <span style={{ fontSize: 10, color: 'var(--gray2)' }}>{sessPage}/{totalPages}</span>
+            <button
+              onClick={() => setSessPage(p => p + 1)}
+              disabled={sessPage >= totalPages}
+              style={pagerStyle(sessPage < totalPages)}
+            >Próx →</button>
+          </div>
+        )}
+      </div>
+
+      {/* ── RIGHT: thread ──────────────────────────────────────────────────── */}
+      {!activeId ? (
+        <div style={{
+          flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
+          color: 'var(--gray2)', fontSize: 13,
+        }}>
+          Selecione uma conversa
+        </div>
+      ) : (
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+
+          {/* header */}
+          <div style={{
+            padding: '11px 18px', borderBottom: '1px solid var(--gray3)',
+            display: 'flex', alignItems: 'center', gap: 12, flexShrink: 0, minHeight: 56,
+          }}>
+            {threadLoading ? (
+              <span style={{ fontSize: 13, color: 'var(--gray2)' }}>Carregando...</span>
+            ) : thread ? (
+              <>
+                <div style={{
+                  width: 34, height: 34, borderRadius: '50%', flexShrink: 0,
+                  background: 'rgba(0,0,0,0.07)',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: 15, fontWeight: 800, color: 'var(--black)',
+                }}>
+                  {(thread.contact.name ?? thread.contact.phone).slice(0, 1).toUpperCase()}
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 14, fontWeight: 800, color: 'var(--black)' }}>
+                    {thread.contact.name ?? thread.contact.phone}
+                  </div>
+                  {thread.contact.name && (
+                    <div style={{ fontSize: 11, color: 'var(--gray2)', fontFamily: 'monospace' }}>
+                      {thread.contact.phone}
+                    </div>
+                  )}
+                </div>
+                <div style={{ flexShrink: 0 }}>
+                  {thread.inWindow ? (
+                    <span style={{
+                      fontSize: 10, fontWeight: 700, padding: '3px 10px', borderRadius: 99,
+                      background: 'rgba(30,138,62,0.08)', color: '#166534',
+                      border: '1px solid rgba(30,138,62,0.22)',
+                    }}>● Janela aberta</span>
+                  ) : (
+                    <span style={{
+                      fontSize: 10, fontWeight: 700, padding: '3px 10px', borderRadius: 99,
+                      background: 'rgba(180,50,0,0.06)', color: '#9a2008',
+                      border: '1px solid rgba(180,50,0,0.18)',
+                    }}>✕ Janela encerrada</span>
+                  )}
+                </div>
+              </>
+            ) : null}
+          </div>
+
+          {/* messages area */}
+          <div style={{
+            flex: 1, overflowY: 'auto', padding: '14px 18px',
+            display: 'flex', flexDirection: 'column', gap: 8,
+          }}>
+            {thread?.messages.length === 0 && (
+              <p style={{ margin: 'auto', fontSize: 12, color: 'var(--gray2)' }}>
+                Nenhuma mensagem nesta conversa
+              </p>
+            )}
+            {thread?.messages.map(m => <Bubble key={m.id} msg={m} />)}
+            <div ref={bottomRef} />
+          </div>
+
+          {/* composer */}
+          {thread && (
+            <div style={{
+              borderTop: '1px solid var(--gray3)', padding: '12px 16px', flexShrink: 0,
+            }}>
+              {sendError && (
+                <div style={{
+                  marginBottom: 8, padding: '7px 12px', borderRadius: 8, fontSize: 12, fontWeight: 600,
+                  background: 'rgba(192,57,43,0.06)', border: '1px solid rgba(192,57,43,0.22)',
+                  color: '#9a2008',
+                }}>
+                  {sendError}
+                </div>
+              )}
+
+              {thread.inWindow ? (
+                <div style={{ display: 'flex', gap: 8, alignItems: 'flex-end' }}>
+                  <textarea
+                    value={textBody}
+                    onChange={e => setTextBody(e.target.value)}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter' && !e.shiftKey) {
+                        e.preventDefault()
+                        void send()
+                      }
+                    }}
+                    placeholder="Digite sua mensagem... (Enter para enviar, Shift+Enter para nova linha)"
+                    rows={2}
+                    style={{
+                      flex: 1, fontFamily: 'inherit', fontSize: 13,
+                      resize: 'none', padding: '9px 13px', borderRadius: 12,
+                      border: '1px solid var(--gray3)', background: 'var(--bg)',
+                      color: 'var(--black)', outline: 'none', lineHeight: 1.5,
+                    }}
+                  />
+                  <SendBtn
+                    label="Enviar"
+                    disabled={!textBody.trim() || sending}
+                    loading={sending}
+                    onClick={() => { void send() }}
+                  />
+                </div>
+              ) : (
+                <TemplateComposer
+                  templates={templates}
+                  loading={tplLoading}
+                  selected={selTemplate}
+                  vars={tplVars}
+                  windowExpiresAt={thread.windowExpiresAt}
+                  sending={sending}
+                  onSelect={selectTemplate}
+                  onVarChange={(i, v) => setTplVars(prev => {
+                    const next = [...prev]
+                    next[i] = v
+                    return next
+                  })}
+                  onSend={() => { void send() }}
+                />
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/(app)/sdr-ia/dashboard/page.tsx
+++ b/app/(app)/sdr-ia/dashboard/page.tsx
@@ -9,6 +9,9 @@ import { DonutChart } from '@/components/widgets/DonutChart'
 import type { DonutSlice } from '@/components/widgets/DonutChart'
 import { DataTable } from '@/components/widgets/DataTable'
 import type { DataTableColumn } from '@/components/widgets/DataTable'
+import { BarChart } from '@/components/widgets/BarChart'
+import type { BarChartItem } from '@/components/widgets/BarChart'
+import { useModules } from '@/components/ModulesProvider'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -21,13 +24,25 @@ const PERIOD_LABELS: Record<Period, string> = {
   '365d': 'Este ano',
 }
 
+interface WaTotals { sent: number; delivered: number; read: number; failed: number; inbound: number }
+interface WaRates  { entrega: number; leitura: number }
+interface WaDay    { date: string; sent: number; delivered: number; read: number; failed: number; inbound: number }
+interface WaBlock  { totals: WaTotals; rates: WaRates; daily: WaDay[] }
+
 interface SdrBiData {
   period: string
   kpis: { contatos: number; taxaResposta: number; reunioes: number; conversao: number }
   funnel: { stageKey: string; stageName: string; count: number; order: number }[]
   sentiment: { id: string; label: string; color: string; count: number }[]
-  recent: { sessionId: string; lastContact: number | null; msgs: number }[]
+  recent: { sessionId: string; source: string; lastContact: number | null; msgs: number }[]
+  whatsapp?: WaBlock
   lastSyncAt: number | null
+}
+
+const WA_ZERO: WaBlock = {
+  totals: { sent: 0, delivered: 0, read: 0, failed: 0, inbound: 0 },
+  rates:  { entrega: 0, leitura: 0 },
+  daily:  [],
 }
 
 // ─── Stage colors ─────────────────────────────────────────────────────────────
@@ -54,6 +69,12 @@ function timeAgo(ms: number | null): string {
   if (hrs < 24) return `${hrs}h`
   const days = Math.floor(hrs / 24)
   return `${days}d`
+}
+
+// Format "YYYY-MM-DD" → "DD/MM" for bar chart labels
+function fmtDay(date: string): string {
+  const parts = date.split('-')
+  return `${parts[2]}/${parts[1]}`
 }
 
 // ─── Local components ─────────────────────────────────────────────────────────
@@ -114,9 +135,31 @@ function PeriodFilter({ value, onChange }: { value: Period; onChange: (p: Period
   )
 }
 
+function SourceBadge({ source }: { source: string }) {
+  const isWa = source === 'ycloud-whatsapp'
+  return (
+    <span style={{
+      display: 'inline-block',
+      fontSize: 10, fontWeight: 700,
+      padding: '2px 8px', borderRadius: 100,
+      background: isWa ? 'rgba(37,211,102,0.10)' : 'rgba(37,99,235,0.08)',
+      color:      isWa ? '#15803d'              : '#1d4ed8',
+      border: `1px solid ${isWa ? 'rgba(37,211,102,0.25)' : 'rgba(37,99,235,0.20)'}`,
+    }}>
+      {isWa ? 'WhatsApp' : 'SDR'}
+    </span>
+  )
+}
+
 // ─── Table columns ────────────────────────────────────────────────────────────
 
 const TABLE_COLS: DataTableColumn[] = [
+  {
+    key: 'source',
+    label: 'Origem',
+    sortable: false,
+    format: (v) => <SourceBadge source={v as string} />,
+  },
   {
     key: 'sessionLabel',
     label: 'Sessão',
@@ -162,6 +205,19 @@ function EmptyState() {
   )
 }
 
+// ─── WhatsApp section header ──────────────────────────────────────────────────
+
+function WaSectionHeader() {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16, marginTop: 8 }}>
+      <div style={{ width: 3, height: 18, borderRadius: 2, background: '#25D366' }} />
+      <div style={{ fontSize: 10, fontWeight: 800, color: 'var(--gray2)', letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+        WhatsApp (YCloud)
+      </div>
+    </div>
+  )
+}
+
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function SdrIaDashboardPage() {
@@ -169,6 +225,9 @@ export default function SdrIaDashboardPage() {
   const [data, setData]       = useState<SdrBiData | null>(null)
   const [loading, setLoading] = useState(true)
   const [ready, setReady]     = useState(false)
+
+  const modules   = useModules()
+  const hasYCloud = modules.includes('integration.ycloud-whatsapp')
 
   // Funnel visibility
   const [visibleStageIds, setVisibleStageIds] = useState<Set<string>>(new Set())
@@ -218,12 +277,21 @@ export default function SdrIaDashboardPage() {
     id: s.id, label: s.label, color: s.color, count: s.count,
   }))
 
-  // Derived table rows
+  // Derived table rows — source field comes from the API
   const tableRows = (data?.recent ?? []).map(r => ({
+    source:       r.source,
     sessionLabel: r.sessionId,
     msgs:         r.msgs,
     lastContact:  r.lastContact ?? 0,
   }))
+
+  // WhatsApp derived data — fallback to zeros so section never crashes
+  const wa: WaBlock = data?.whatsapp ?? WA_ZERO
+
+  // Daily chart capped at last 30 data points for bar readability
+  const waDailyChart = wa.daily.slice(-30)
+  const waDailyInbound: BarChartItem[] = waDailyChart.map(d => ({ label: fmtDay(d.date), count: d.inbound }))
+  const waDailySent:    BarChartItem[] = waDailyChart.map(d => ({ label: fmtDay(d.date), count: d.sent    }))
 
   const hasData = (data?.funnel.length ?? 0) > 0 || (data?.recent.length ?? 0) > 0
 
@@ -267,7 +335,7 @@ export default function SdrIaDashboardPage() {
 
       {!loading && hasData && (
         <>
-          {/* ── KPI Cards ──────────────────────────────────────────── */}
+          {/* ── KPI Cards (SDR) ────────────────────────────────────── */}
           <div className="animate-slide-up delay-2" style={{ display: 'grid', gridTemplateColumns: 'repeat(4, minmax(0, 1fr))', gap: 14, marginBottom: 24 }}>
             <KpiCard
               label="Contatos realizados"
@@ -352,9 +420,69 @@ export default function SdrIaDashboardPage() {
             )}
           </div>
 
+          {/* ── WhatsApp (YCloud) section — conditional on module ──── */}
+          {hasYCloud && (
+            <div className="animate-slide-up delay-4">
+              <WaSectionHeader />
+
+              {/* 4 volume cards */}
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, minmax(0, 1fr))', gap: 14, marginBottom: 14 }}>
+                <KpiCard label="Recebidas"  value={wa.totals.inbound}   accent="#0891B2" sub="mensagens inbound" />
+                <KpiCard label="Enviadas"   value={wa.totals.sent}      accent="#64748B" sub="mensagens outbound" />
+                <KpiCard label="Entregues"  value={wa.totals.delivered} accent="#2563EB" />
+                <KpiCard label="Lidas"      value={wa.totals.read}      accent="#1E8A3E" />
+              </div>
+
+              {/* 3 rate / failure cards */}
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 14, marginBottom: 20 }}>
+                <KpiCard
+                  label="Taxa de entrega"
+                  value={Math.round(wa.rates.entrega * 100)}
+                  format={v => `${v}%`}
+                  accent="#2563EB"
+                  sub={`${wa.totals.delivered.toLocaleString('pt-BR')} de ${wa.totals.sent.toLocaleString('pt-BR')} enviadas`}
+                />
+                <KpiCard
+                  label="Taxa de leitura"
+                  value={Math.round(wa.rates.leitura * 100)}
+                  format={v => `${v}%`}
+                  accent="#1E8A3E"
+                  sub={`${wa.totals.read.toLocaleString('pt-BR')} de ${wa.totals.delivered.toLocaleString('pt-BR')} entregues`}
+                />
+                <KpiCard label="Falhas"   value={wa.totals.failed}    accent="#D93025" sub="mensagens não entregues" />
+              </div>
+
+              {/* Daily charts — only when there are data points */}
+              {waDailyChart.length > 0 && (
+                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 16, marginBottom: 20 }}>
+                  <div style={{ background: 'var(--white)', borderRadius: 16, border: '1px solid var(--gray3)', padding: '20px 24px' }}>
+                    <SectionTitle>Recebidas por dia</SectionTitle>
+                    <BarChart data={waDailyInbound} ready={ready} unit="mensagem" />
+                  </div>
+                  <div style={{ background: 'var(--white)', borderRadius: 16, border: '1px solid var(--gray3)', padding: '20px 24px' }}>
+                    <SectionTitle>Enviadas por dia</SectionTitle>
+                    <BarChart data={waDailySent} ready={ready} unit="mensagem" />
+                  </div>
+                </div>
+              )}
+
+              {/* Empty state for when module is enabled but no data yet */}
+              {waDailyChart.length === 0 && wa.totals.inbound === 0 && wa.totals.sent === 0 && (
+                <div style={{
+                  padding: '20px 24px', marginBottom: 20,
+                  background: 'var(--bg)', border: '1px solid var(--gray3)',
+                  borderRadius: 16, textAlign: 'center',
+                  fontSize: 13, color: 'var(--gray2)', fontWeight: 500,
+                }}>
+                  Nenhuma mensagem WhatsApp no período. Os dados aparecem aqui assim que o primeiro webhook for recebido ou o backfill concluir.
+                </div>
+              )}
+            </div>
+          )}
+
           {/* ── Tabela de sessões recentes ─────────────────────────── */}
           {tableRows.length > 0 && (
-            <div className="animate-slide-up delay-4" style={{ background: 'var(--white)', borderRadius: 16, border: '1px solid var(--gray3)', overflow: 'hidden' }}>
+            <div className="animate-slide-up delay-5" style={{ background: 'var(--white)', borderRadius: 16, border: '1px solid var(--gray3)', overflow: 'hidden' }}>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '14px 20px', borderBottom: '1px solid var(--gray3)', background: 'var(--bg)' }}>
                 <div style={{ fontSize: 10, fontWeight: 800, color: 'var(--gray2)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>
                   Sessões recentes — {tableRows.length} conversas

--- a/app/(app)/sdr-ia/layout.tsx
+++ b/app/(app)/sdr-ia/layout.tsx
@@ -4,8 +4,10 @@ import { usePathname } from 'next/navigation'
 import { useModules } from '@/components/ModulesProvider'
 
 const TABS = [
-  { href: '/sdr-ia/dashboard', label: 'Dashboard',  moduleKey: 'sdr.dashboard'  },
-  { href: '/sdr-ia/parametros', label: 'Parâmetros', moduleKey: 'sdr.parametros' },
+  { href: '/sdr-ia/dashboard',  label: 'Dashboard',  moduleKey: 'sdr.dashboard'               },
+  { href: '/sdr-ia/parametros', label: 'Parâmetros', moduleKey: 'sdr.parametros'              },
+  { href: '/sdr-ia/contatos',   label: 'Contatos',   moduleKey: 'integration.ycloud-whatsapp' },
+  { href: '/sdr-ia/conversas',  label: 'Conversas',  moduleKey: 'integration.ycloud-whatsapp' },
 ]
 
 export default function SdrIaLayout({ children }: { children: React.ReactNode }) {

--- a/app/(app)/settings/integrations/ycloud/page.tsx
+++ b/app/(app)/settings/integrations/ycloud/page.tsx
@@ -1,0 +1,562 @@
+'use client'
+import Link from 'next/link'
+import { useState, useEffect, useCallback } from 'react'
+
+interface SourceData {
+  configured: boolean
+  status?: string
+  lastSyncStatus?: string | null
+  lastSyncError?: string | null
+  apiKeyMasked?: string | null
+  fromPhone?: string | null
+  webhookUrl?: string | null
+}
+
+function EyeIcon({ open }: { open: boolean }) {
+  if (open) {
+    return (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+        <line x1="1" y1="1" x2="23" y2="23" />
+      </svg>
+    )
+  }
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  )
+}
+
+function SpinIcon() {
+  return (
+    <svg
+      width="14" height="14" viewBox="0 0 16 16" fill="none"
+      stroke="currentColor" strokeWidth="2"
+      style={{ animation: 'spin 1s linear infinite' }}
+    >
+      <path d="M1 4v5h5M15 12v-5h-5" />
+      <path d="M13.4 7A6 6 0 1 0 12 12.3" />
+    </svg>
+  )
+}
+
+function CopyIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <rect x="9" y="9" width="13" height="13" rx="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  )
+}
+
+function CheckSmIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="var(--green)" strokeWidth="2">
+      <path d="M2 6l3 3 5-5" />
+    </svg>
+  )
+}
+
+function XSmIcon({ color = '#b02619' }: { color?: string }) {
+  return (
+    <svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke={color} strokeWidth="2">
+      <path d="M2 2l8 8M10 2L2 10" />
+    </svg>
+  )
+}
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '10px 44px 10px 14px',
+  fontFamily: 'monospace',
+  fontSize: 13,
+  fontWeight: 500,
+  color: 'var(--black)',
+  background: 'var(--white)',
+  border: '1px solid var(--gray3)',
+  borderRadius: 'var(--radius-sm)',
+  outline: 'none',
+  boxSizing: 'border-box',
+}
+
+const plainInputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '10px 14px',
+  fontFamily: 'inherit',
+  fontSize: 13,
+  fontWeight: 600,
+  color: 'var(--black)',
+  background: 'var(--white)',
+  border: '1px solid var(--gray3)',
+  borderRadius: 'var(--radius-sm)',
+  outline: 'none',
+  boxSizing: 'border-box',
+}
+
+function PlainField({
+  label,
+  value,
+  onChange,
+  placeholder,
+  helper,
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  placeholder?: string
+  helper?: string
+}) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 20 }}>
+      <label style={{ fontSize: 12, fontWeight: 700, color: 'var(--gray)', letterSpacing: '0.04em' }}>
+        {label}
+      </label>
+      <input
+        type="text"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        placeholder={placeholder}
+        style={plainInputStyle}
+        onFocus={e => {
+          e.target.style.borderColor = 'var(--primary)'
+          e.target.style.boxShadow = '0 0 0 3px var(--primary-dim)'
+        }}
+        onBlur={e => {
+          e.target.style.borderColor = 'var(--gray3)'
+          e.target.style.boxShadow = 'none'
+        }}
+      />
+      {helper && (
+        <div style={{ fontSize: 11, color: 'var(--gray2)', fontWeight: 500, lineHeight: 1.5 }}>
+          {helper}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SecretField({
+  label,
+  value,
+  onChange,
+  show,
+  onToggle,
+  placeholder,
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  show: boolean
+  onToggle: () => void
+  placeholder?: string
+}) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 20 }}>
+      <label style={{ fontSize: 12, fontWeight: 700, color: 'var(--gray)', letterSpacing: '0.04em' }}>
+        {label}
+      </label>
+      <div style={{ position: 'relative' }}>
+        <input
+          type={show ? 'text' : 'password'}
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder={placeholder}
+          style={inputStyle}
+          onFocus={e => {
+            e.target.style.borderColor = 'var(--primary)'
+            e.target.style.boxShadow = '0 0 0 3px var(--primary-dim)'
+          }}
+          onBlur={e => {
+            e.target.style.borderColor = 'var(--gray3)'
+            e.target.style.boxShadow = 'none'
+          }}
+        />
+        <button
+          type="button"
+          onClick={onToggle}
+          style={{
+            position: 'absolute', right: 12, top: '50%',
+            transform: 'translateY(-50%)', background: 'none',
+            border: 'none', cursor: 'pointer', color: 'var(--gray2)', padding: 2,
+          }}
+        >
+          <EyeIcon open={show} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default function YCloudPage() {
+  const [sourceData, setSourceData] = useState<SourceData | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const [apiKey, setApiKey] = useState('')
+  const [webhookSecret, setWebhookSecret] = useState('')
+  const [fromPhone, setFromPhone] = useState('')
+  const [showApiKey, setShowApiKey] = useState(false)
+  const [showSecret, setShowSecret] = useState(false)
+
+  const [testResult, setTestResult] = useState<{ valid: boolean; error?: string } | null>(null)
+  const [testing, setTesting] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  // Webhook URL returned after a successful save — takes priority over sourceData.webhookUrl
+  const [savedWebhookUrl, setSavedWebhookUrl] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const fetchStatus = useCallback(() => {
+    return fetch('/api/ycloud/source')
+      .then(r => r.json())
+      .then((d: SourceData) => setSourceData(d))
+      .catch(() => {})
+  }, [])
+
+  useEffect(() => {
+    fetchStatus().finally(() => setLoading(false))
+  }, [fetchStatus])
+
+  // Pre-fill fromPhone from API (not a secret — returned in plain text).
+  // Runs on initial load and after a successful save so the field stays in sync.
+  useEffect(() => {
+    if (sourceData?.fromPhone) setFromPhone(sourceData.fromPhone)
+  }, [sourceData])
+
+  async function testConnection() {
+    if (!apiKey || !webhookSecret) return
+    setTesting(true)
+    setTestResult(null)
+    try {
+      const res = await fetch('/api/ycloud/source/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ apiKey, webhookSecret }),
+      })
+      const data = await res.json()
+      setTestResult(data)
+    } catch {
+      setTestResult({ valid: false, error: 'Falha na conexão com o servidor' })
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  async function saveSource() {
+    if (!apiKey || !webhookSecret || !fromPhone) return
+    setSaving(true)
+    setSaveError(null)
+    try {
+      const res = await fetch('/api/ycloud/source', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ apiKey, webhookSecret, fromPhone }),
+      })
+      const data = await res.json()
+      if (!data.ok) {
+        setSaveError(data.error ?? 'Erro ao salvar')
+        return
+      }
+      setSavedWebhookUrl(data.webhookUrl ?? null)
+      setApiKey('')
+      setWebhookSecret('')
+      setTestResult(null)
+      await fetchStatus()
+    } catch {
+      setSaveError('Erro de rede ao salvar')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function copyUrl(url: string) {
+    navigator.clipboard.writeText(url).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }).catch(() => {})
+  }
+
+  if (loading) return null
+
+  const canTest = apiKey.trim().length > 0 && webhookSecret.trim().length > 0 && !testing && !saving
+  const canSave = apiKey.trim().length > 0 && webhookSecret.trim().length > 0 && fromPhone.trim().length > 0 && !saving
+  const displayUrl = savedWebhookUrl ?? sourceData?.webhookUrl
+
+  return (
+    <div>
+      {/* Back link */}
+      <Link
+        href="/settings?tab=integracoes"
+        style={{
+          display: 'inline-flex', alignItems: 'center', gap: 6,
+          fontSize: 13, fontWeight: 600, color: 'var(--gray)',
+          textDecoration: 'none', marginBottom: 20,
+        }}
+      >
+        ← Voltar para Integrações
+      </Link>
+
+      {/* Header */}
+      <div className="animate-slide-up delay-1" style={{ marginBottom: 24 }}>
+        <div style={{ fontSize: 22, fontWeight: 800, color: 'var(--black)', letterSpacing: '-0.02em' }}>
+          YCloud (WhatsApp)
+        </div>
+        <div style={{ fontSize: 13, color: 'var(--gray)', marginTop: 2 }}>
+          Receba mensagens WhatsApp via webhook e sincronize conversas automaticamente no painel
+        </div>
+      </div>
+
+      {/* Status card — only when configured */}
+      {sourceData?.configured && (
+        <div
+          className="animate-slide-up delay-2"
+          style={{
+            background: 'var(--white)', border: '1px solid var(--gray3)',
+            borderRadius: 'var(--radius-lg)', padding: 20, marginBottom: 16,
+            boxShadow: 'var(--shadow)',
+          }}
+        >
+          <div style={{
+            fontSize: 11, fontWeight: 800, textTransform: 'uppercase',
+            letterSpacing: '0.08em', color: 'var(--gray2)',
+            paddingBottom: 12, borderBottom: '1px solid var(--gray3)', marginBottom: 14,
+          }}>
+            Status da integração
+          </div>
+
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 12, marginBottom: displayUrl ? 14 : 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, fontWeight: 600, color: 'var(--green)' }}>
+              <div style={{ width: 8, height: 8, borderRadius: '50%', background: 'var(--green)', flexShrink: 0 }} />
+              Conectado
+            </div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}>
+              {sourceData.apiKeyMasked && (
+                <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--gray2)', fontFamily: 'monospace' }}>
+                  API Key: {sourceData.apiKeyMasked}
+                </span>
+              )}
+              {sourceData.fromPhone && (
+                <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--gray2)', fontFamily: 'monospace' }}>
+                  Remetente: {sourceData.fromPhone}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Webhook URL in status card */}
+          {displayUrl && !savedWebhookUrl && (
+            <WebhookUrlBox url={displayUrl} copied={copied} onCopy={copyUrl} />
+          )}
+        </div>
+      )}
+
+      {/* Success panel — shown after a save */}
+      {savedWebhookUrl && (
+        <div
+          className="animate-slide-up delay-2"
+          style={{
+            background: 'rgba(30,138,62,0.04)',
+            border: '1px solid rgba(30,138,62,0.25)',
+            borderRadius: 'var(--radius-lg)', padding: 20, marginBottom: 16,
+          }}
+        >
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: 8,
+            fontSize: 13, fontWeight: 700, color: '#145c2a', marginBottom: 14,
+          }}>
+            <CheckSmIcon />
+            Integração salva com sucesso!
+          </div>
+
+          <div style={{ fontSize: 13, color: '#145c2a', fontWeight: 500, marginBottom: 12, lineHeight: 1.6 }}>
+            Cole a URL abaixo no painel do YCloud em{' '}
+            <strong>Console → Webhooks</strong> e selecione os eventos{' '}
+            <code style={{ fontSize: 12, background: 'rgba(30,138,62,0.1)', padding: '1px 5px', borderRadius: 4 }}>
+              whatsapp.inbound_message.received
+            </code>{' '}
+            e{' '}
+            <code style={{ fontSize: 12, background: 'rgba(30,138,62,0.1)', padding: '1px 5px', borderRadius: 4 }}>
+              whatsapp.message.updated
+            </code>.
+          </div>
+
+          <WebhookUrlBox url={savedWebhookUrl} copied={copied} onCopy={copyUrl} />
+        </div>
+      )}
+
+      {/* Config card */}
+      <div
+        className="animate-slide-up delay-3"
+        style={{
+          background: 'var(--white)', border: '1px solid var(--gray3)',
+          borderRadius: 'var(--radius-lg)', padding: 24, boxShadow: 'var(--shadow)',
+        }}
+      >
+        <div style={{
+          fontSize: 11, fontWeight: 800, textTransform: 'uppercase',
+          letterSpacing: '0.08em', color: 'var(--gray2)',
+          paddingBottom: 14, borderBottom: '1px solid var(--gray3)', marginBottom: 20,
+        }}>
+          {sourceData?.configured ? 'Atualizar credenciais' : 'Configurar integração'}
+        </div>
+
+        {/* Existing key hint */}
+        {sourceData?.configured && sourceData.apiKeyMasked && (
+          <div style={{
+            padding: '10px 14px', background: 'var(--bg)',
+            border: '1px solid var(--gray3)', borderRadius: 'var(--radius-sm)',
+            marginBottom: 16, fontSize: 13, fontWeight: 600, color: 'var(--gray)',
+          }}>
+            API Key atual:{' '}
+            <span style={{ fontFamily: 'monospace', color: 'var(--black)' }}>
+              {sourceData.apiKeyMasked}
+            </span>
+            {' '}— insira novas credenciais para alterar
+          </div>
+        )}
+
+        <SecretField
+          label="API KEY DO YCLOUD"
+          value={apiKey}
+          onChange={v => { setApiKey(v); setTestResult(null); setSaveError(null) }}
+          show={showApiKey}
+          onToggle={() => setShowApiKey(v => !v)}
+          placeholder="sua-api-key-do-ycloud"
+        />
+
+        <SecretField
+          label="SEGREDO DO WEBHOOK (WEBHOOK SECRET)"
+          value={webhookSecret}
+          onChange={v => { setWebhookSecret(v); setTestResult(null); setSaveError(null) }}
+          show={showSecret}
+          onToggle={() => setShowSecret(v => !v)}
+          placeholder="segredo-gerado-no-ycloud"
+        />
+
+        <PlainField
+          label="NÚMERO REMETENTE (WHATSAPP)"
+          value={fromPhone}
+          onChange={v => { setFromPhone(v); setSaveError(null) }}
+          placeholder="+5511999999999"
+          helper="Número do WhatsApp Business usado como remetente, em formato internacional (E.164)."
+        />
+
+        <div style={{ fontSize: 12, color: 'var(--gray2)', fontWeight: 500, marginTop: -12, marginBottom: 20 }}>
+          API Key e Webhook Secret são armazenados criptografados (AES-256-GCM).
+        </div>
+
+        {/* Test result badge */}
+        {testResult && (
+          <div style={{
+            marginBottom: 16, padding: '10px 14px', borderRadius: 'var(--radius-sm)',
+            fontSize: 13, fontWeight: 600,
+            display: 'flex', alignItems: 'center', gap: 8,
+            background: testResult.valid ? 'rgba(30,138,62,0.06)' : 'rgba(217,48,37,0.06)',
+            border: `1px solid ${testResult.valid ? 'rgba(30,138,62,0.25)' : 'rgba(217,48,37,0.2)'}`,
+            color: testResult.valid ? '#145c2a' : '#b02619',
+          }}>
+            {testResult.valid ? (
+              <><CheckSmIcon />API Key válida — conexão bem-sucedida</>
+            ) : (
+              <><XSmIcon />{testResult.error ?? 'Falha na conexão'}</>
+            )}
+          </div>
+        )}
+
+        {/* Save error */}
+        {saveError && (
+          <div style={{
+            marginBottom: 16, padding: '10px 14px', borderRadius: 'var(--radius-sm)',
+            fontSize: 13, fontWeight: 600, color: '#b02619',
+            background: 'rgba(217,48,37,0.06)', border: '1px solid rgba(217,48,37,0.2)',
+            display: 'flex', alignItems: 'center', gap: 8,
+          }}>
+            <XSmIcon />{saveError}
+          </div>
+        )}
+
+        {/* Action buttons */}
+        <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            onClick={testConnection}
+            disabled={!canTest}
+            style={{
+              padding: '10px 18px', fontFamily: 'inherit', fontSize: 13, fontWeight: 700,
+              background: 'var(--bg)', border: '1px solid var(--gray3)',
+              borderRadius: 'var(--radius-pill)', cursor: canTest ? 'pointer' : 'not-allowed',
+              color: 'var(--black)', opacity: !canTest ? 0.5 : 1,
+              display: 'flex', alignItems: 'center', gap: 7,
+            }}
+          >
+            {testing && <SpinIcon />}
+            {testing ? 'Testando…' : 'Testar conexão'}
+          </button>
+
+          <button
+            type="button"
+            onClick={saveSource}
+            disabled={!canSave}
+            style={{
+              padding: '10px 22px', fontFamily: 'inherit', fontSize: 13, fontWeight: 700,
+              background: 'var(--primary)', border: 'none',
+              borderRadius: 'var(--radius-pill)', cursor: canSave ? 'pointer' : 'not-allowed',
+              color: 'var(--primary-contrast)', opacity: !canSave ? 0.5 : 1,
+              display: 'flex', alignItems: 'center', gap: 7,
+            }}
+          >
+            {saving && <SpinIcon />}
+            {saving ? 'Salvando…' : 'Salvar e conectar'}
+          </button>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes spin {
+          from { transform: rotate(0deg) }
+          to   { transform: rotate(360deg) }
+        }
+      `}</style>
+    </div>
+  )
+}
+
+// ─── Reusable webhook URL display ─────────────────────────────────────────────
+
+function WebhookUrlBox({ url, copied, onCopy }: { url: string; copied: boolean; onCopy: (u: string) => void }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 10,
+      background: 'var(--bg)', border: '1px solid var(--gray3)',
+      borderRadius: 'var(--radius-sm)', padding: '10px 14px',
+    }}>
+      <span style={{
+        flex: 1, fontFamily: 'monospace', fontSize: 12, fontWeight: 600,
+        color: 'var(--black)', wordBreak: 'break-all',
+      }}>
+        {url}
+      </span>
+      <button
+        type="button"
+        onClick={() => onCopy(url)}
+        title="Copiar URL"
+        style={{
+          flexShrink: 0, padding: '6px 12px',
+          fontFamily: 'inherit', fontSize: 12, fontWeight: 700,
+          background: copied ? 'rgba(30,138,62,0.08)' : 'var(--white)',
+          border: `1px solid ${copied ? 'rgba(30,138,62,0.3)' : 'var(--gray3)'}`,
+          borderRadius: 'var(--radius-sm)',
+          color: copied ? '#145c2a' : 'var(--gray)',
+          cursor: 'pointer',
+          display: 'flex', alignItems: 'center', gap: 5,
+          transition: 'all .15s',
+        }}
+      >
+        {copied ? <CheckSmIcon /> : <CopyIcon />}
+        {copied ? 'Copiado!' : 'Copiar'}
+      </button>
+    </div>
+  )
+}

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -52,6 +52,14 @@ function TikTokAdsIcon() {
   )
 }
 
+function YCloudIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="#25D366">
+      <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413Z"/>
+    </svg>
+  )
+}
+
 // ─── Integration groups config ────────────────────────────────────────────────
 
 interface IntegrationItem {
@@ -119,6 +127,20 @@ const INTEGRATION_GROUPS: { group: string; items: IntegrationItem[] }[] = [
         href: '/settings/integrations/tiktok-ads',
         iconBg: '#111',
         icon: <TikTokAdsIcon />,
+      },
+    ],
+  },
+  {
+    group: 'Mensageria',
+    items: [
+      {
+        slug: 'ycloud-whatsapp',
+        label: 'YCloud (WhatsApp)',
+        desc: 'Receba mensagens WhatsApp via webhook e sincronize conversas.',
+        href: '/settings/integrations/ycloud',
+        iconBg: '#f0fdf4',
+        iconColor: '#16a34a',
+        icon: <YCloudIcon />,
       },
     ],
   },
@@ -208,7 +230,7 @@ export default function SettingsPage() {
   useEffect(() => {
     if (tab !== 'integracoes' || integFetched) return
     setIntegFetched(true)
-    setIntegStatuses({ kommo: 'loading', 'google-ads': 'loading', 'meta-ads': 'loading', 'tiktok-ads': 'loading', ai: 'loading', 'sdr-source': 'loading' })
+    setIntegStatuses({ kommo: 'loading', 'google-ads': 'loading', 'meta-ads': 'loading', 'tiktok-ads': 'loading', ai: 'loading', 'sdr-source': 'loading', 'ycloud-whatsapp': 'loading' })
 
     Promise.all([
       fetch('/api/kommo/sync').then(r => r.ok ? r.json() : null).catch(() => null),
@@ -217,14 +239,16 @@ export default function SettingsPage() {
       fetch('/api/ads/tiktok_ads').then(r => r.ok ? r.json() : null).catch(() => null),
       fetch('/api/ai-settings').then(r => r.ok ? r.json() : null).catch(() => null),
       fetch('/api/sdr/source').then(r => r.ok ? r.json() : null).catch(() => null),
-    ]).then(([kommo, google, meta, tiktok, ai, sdrSource]) => {
+      fetch('/api/ycloud/source').then(r => r.ok ? r.json() : null).catch(() => null),
+    ]).then(([kommo, google, meta, tiktok, ai, sdrSource, ycloud]) => {
       setIntegStatuses({
-        'kommo':       kommo?.status === 'connected' ? 'connected' : 'disconnected',
-        'google-ads':  google?.accountId != null ? 'connected' : 'disconnected',
-        'meta-ads':    meta?.accountId != null ? 'connected' : 'disconnected',
-        'tiktok-ads':  tiktok?.accountId != null ? 'connected' : 'disconnected',
-        'ai':          ai?.configured ? 'connected' : 'disconnected',
-        'sdr-source':  sdrSource?.configured ? 'connected' : 'disconnected',
+        'kommo':            kommo?.status === 'connected' ? 'connected' : 'disconnected',
+        'google-ads':       google?.accountId != null ? 'connected' : 'disconnected',
+        'meta-ads':         meta?.accountId != null ? 'connected' : 'disconnected',
+        'tiktok-ads':       tiktok?.accountId != null ? 'connected' : 'disconnected',
+        'ai':               ai?.configured ? 'connected' : 'disconnected',
+        'sdr-source':       sdrSource?.configured ? 'connected' : 'disconnected',
+        'ycloud-whatsapp':  ycloud?.configured ? 'connected' : 'disconnected',
       })
     })
   }, [tab, integFetched])

--- a/app/api/bi/sdr/route.ts
+++ b/app/api/bi/sdr/route.ts
@@ -1,11 +1,29 @@
+// GET /api/bi/sdr?period=30d|90d|180d|365d
+//
+// Response shape:
+// {
+//   period: string,
+//   kpis:      { contatos, taxaResposta, reunioes, conversao },
+//   funnel:    { stageKey, stageName, count, order }[],
+//   sentiment: { id, label, color, count }[],   -- source='supabase-n8n' only
+//   recent:    { sessionId, source, lastContact, msgs }[], -- top 50 across both sources
+//   whatsapp:  {
+//     totals: { sent, delivered, read, failed, inbound },
+//     rates:  { entrega, leitura },              -- 0 when denominator is 0
+//     daily:  { date:'YYYY-MM-DD', sent, delivered, read, failed, inbound }[],
+//   },
+//   lastSyncAt: number | null,
+// }
+
 import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
 import { db } from '@/lib/db'
 import { events, conversations, funnelSnapshots, dataSources } from '@/lib/db/schema'
-import { and, desc, eq, gte, lte, sql } from 'drizzle-orm'
+import { and, desc, eq, gte, inArray, lte, sql } from 'drizzle-orm'
 import { assertEntitlement } from '@/lib/entitlements'
 
 const DAY = 86_400_000
+const WA_LIMIT = 5_000
 
 const PERIOD_DAYS: Record<string, number> = {
   '30d': 30, '90d': 90, '180d': 180, '365d': 365,
@@ -13,6 +31,16 @@ const PERIOD_DAYS: Record<string, number> = {
 
 function toYearMonth(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+}
+
+function toYMD(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+type WaBucket = { sent: number; delivered: number; read: number; failed: number; inbound: number }
+
+function zeroBucket(): WaBucket {
+  return { sent: 0, delivered: 0, read: 0, failed: 0, inbound: 0 }
 }
 
 export async function GET(request: Request) {
@@ -32,7 +60,7 @@ export async function GET(request: Request) {
   const startMonth = toYearMonth(periodStart)
   const endMonth = toYearMonth(now)
 
-  // ── Funnel snapshots: aggregate by stageKey over the period range ────────
+  // ── Funnel snapshots: aggregate by stageKey over the period range ─────────
   const funnelRows = await db
     .select({
       stageKey:  funnelSnapshots.stageKey,
@@ -50,7 +78,7 @@ export async function GET(request: Request) {
     .groupBy(funnelSnapshots.stageKey, funnelSnapshots.stageName)
     .orderBy(sql`min(${funnelSnapshots.order})`)
 
-  // ── Events: sentiment distribution ──────────────────────────────────────
+  // ── Events: sentiment (supabase-n8n only — YCloud events have null sentiment) ─
   const sentimentRows = await db
     .select({
       sentiment: events.sentiment,
@@ -64,22 +92,24 @@ export async function GET(request: Request) {
     ))
     .groupBy(events.sentiment)
 
-  // ── Conversations: recent sessions (por created_at → occurredAt) ─────────
+  // ── Conversations: recent sessions across both SDR and WhatsApp sources ───
+  //    occurredAt is mode:'timestamp' → Drizzle returns Date; .getTime() = epoch ms
   const convRows = await db
     .select({
+      source:     conversations.source,
       sessionId:  conversations.sessionId,
       occurredAt: conversations.occurredAt,
     })
     .from(conversations)
     .where(and(
       eq(conversations.tenantId, tenantId),
-      eq(conversations.source, 'supabase-n8n'),
+      inArray(conversations.source, ['supabase-n8n', 'ycloud-whatsapp']),
       gte(conversations.occurredAt, periodStart),
     ))
     .orderBy(desc(conversations.occurredAt))
     .limit(2000)
 
-  // ── Data source for lastSyncAt ───────────────────────────────────────────
+  // ── Data source for lastSyncAt ────────────────────────────────────────────
   const [ds] = await db
     .select({ lastSyncAt: dataSources.lastSyncAt })
     .from(dataSources)
@@ -89,7 +119,64 @@ export async function GET(request: Request) {
     ))
     .limit(1)
 
-  // ── Derive KPIs from funnel ──────────────────────────────────────────────
+  // ── WhatsApp totals: exact SQL GROUP BY / COUNT — no row limit ───────────
+  const yEvCountRows = await db
+    .select({
+      eventType: events.eventType,
+      count:     sql<number>`count(*)`,
+    })
+    .from(events)
+    .where(and(
+      eq(events.tenantId, tenantId),
+      eq(events.source, 'ycloud-whatsapp'),
+      gte(events.occurredAt, periodStart),
+    ))
+    .groupBy(events.eventType)
+
+  const [yConvCountRow] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(conversations)
+    .where(and(
+      eq(conversations.tenantId, tenantId),
+      eq(conversations.source, 'ycloud-whatsapp'),
+      eq(conversations.role, 'human'),
+      gte(conversations.occurredAt, periodStart),
+    ))
+
+  // ── WhatsApp daily series: row fetch for JS bucketisation (capped) ────────
+  //    Totals come from the SQL aggregates above; these rows only power the chart.
+  const yEvRows = await db
+    .select({ eventType: events.eventType, occurredAt: events.occurredAt })
+    .from(events)
+    .where(and(
+      eq(events.tenantId, tenantId),
+      eq(events.source, 'ycloud-whatsapp'),
+      gte(events.occurredAt, periodStart),
+    ))
+    .orderBy(desc(events.occurredAt))
+    .limit(WA_LIMIT)
+
+  if (yEvRows.length === WA_LIMIT) {
+    console.warn(`[bi sdr whatsapp] série diária truncada em ${WA_LIMIT} linhas (events); totais permanecem exatos via SQL`)
+  }
+
+  const yConvRows = await db
+    .select({ occurredAt: conversations.occurredAt })
+    .from(conversations)
+    .where(and(
+      eq(conversations.tenantId, tenantId),
+      eq(conversations.source, 'ycloud-whatsapp'),
+      eq(conversations.role, 'human'),
+      gte(conversations.occurredAt, periodStart),
+    ))
+    .orderBy(desc(conversations.occurredAt))
+    .limit(WA_LIMIT)
+
+  if (yConvRows.length === WA_LIMIT) {
+    console.warn(`[bi sdr whatsapp] série diária truncada em ${WA_LIMIT} linhas (conversations); totais permanecem exatos via SQL`)
+  }
+
+  // ── Derive KPIs from funnel ───────────────────────────────────────────────
   const funnelMap = new Map(funnelRows.map(r => [r.stageKey, Number(r.count)]))
   const leadsCount     = funnelMap.get('leads')     ?? 0
   const contactedCount = funnelMap.get('contacted') ?? 0
@@ -101,7 +188,7 @@ export async function GET(request: Request) {
   const conversao = leadsCount > 0
     ? Math.round((meetingsCount / leadsCount) * 100) : 0
 
-  // ── Sentiment donut ──────────────────────────────────────────────────────
+  // ── Sentiment donut ───────────────────────────────────────────────────────
   const sentMap = new Map<string, number>()
   for (const r of sentimentRows) {
     const key = r.sentiment ?? 'unknown'
@@ -114,22 +201,72 @@ export async function GET(request: Request) {
     { id: 'unknown',  label: 'Sem análise', color: '#AAAAAA', count: sentMap.get('unknown')  ?? 0 },
   ].filter(s => s.count > 0)
 
-  // ── Dedup por sessionId; recência = maior occurredAt da sessão ──────────
-  const sessionMap = new Map<string, { lastContact: number | null; msgs: number }>()
+  // ── Recent sessions: dedup by (source, sessionId); top 50 by recência ────
+  //    Key = `${source}:${sessionId}` so same phone in YCloud and SDR don't collapse
+  const sessionMap = new Map<string, { source: string; sessionId: string; lastContact: number | null; msgs: number }>()
   for (const row of convRows) {
-    const ms = row.occurredAt instanceof Date ? row.occurredAt.getTime() : null
-    const ex = sessionMap.get(row.sessionId)
+    const key = `${row.source}:${row.sessionId}`
+    const ms  = row.occurredAt instanceof Date ? row.occurredAt.getTime() : null
+    const ex  = sessionMap.get(key)
     if (!ex) {
-      sessionMap.set(row.sessionId, { lastContact: ms, msgs: 1 })
+      sessionMap.set(key, { source: row.source, sessionId: row.sessionId, lastContact: ms, msgs: 1 })
     } else {
       ex.msgs++
       if (ms && (!ex.lastContact || ms > ex.lastContact)) ex.lastContact = ms
     }
   }
-  const recent = Array.from(sessionMap.entries())
-    .sort((a, b) => (b[1].lastContact ?? 0) - (a[1].lastContact ?? 0))
+  const recent = Array.from(sessionMap.values())
+    .sort((a, b) => (b.lastContact ?? 0) - (a.lastContact ?? 0))
     .slice(0, 50)
-    .map(([sessionId, { lastContact, msgs }]) => ({ sessionId, lastContact, msgs }))
+    .map(({ source, sessionId, lastContact, msgs }) => ({ sessionId, source, lastContact, msgs }))
+
+  // ── WhatsApp metrics ──────────────────────────────────────────────────────
+  //
+  //  Totals: exact SQL aggregates (no row limit — always correct).
+  //  Daily series: JS bucketisation over the capped row fetch (chart only).
+  //  occurredAt is mode:'timestamp' → Drizzle returns Date; .getTime() = epoch ms.
+  //  Local-time bucket (toYMD) matches toYearMonth convention; avoids SQLite
+  //  date() UTC ambiguity — same pattern as /api/bi leadsPerWeek.
+
+  const evCountMap = new Map(yEvCountRows.map(r => [r.eventType, Number(r.count)]))
+  const waTotals: WaBucket = {
+    sent:      evCountMap.get('whatsapp_status_sent')      ?? 0,
+    delivered: evCountMap.get('whatsapp_status_delivered') ?? 0,
+    read:      evCountMap.get('whatsapp_status_read')      ?? 0,
+    failed:    evCountMap.get('whatsapp_status_failed')    ?? 0,
+    inbound:   Number(yConvCountRow?.count ?? 0),
+  }
+
+  // Daily series — bucketise the (possibly capped) row fetches in JS
+  const waDailyMap = new Map<string, WaBucket>()
+
+  for (const row of yEvRows) {
+    if (!(row.occurredAt instanceof Date)) continue
+    const day = toYMD(row.occurredAt)
+    if (!waDailyMap.has(day)) waDailyMap.set(day, zeroBucket())
+    const b = waDailyMap.get(day)!
+    switch (row.eventType) {
+      case 'whatsapp_status_sent':      b.sent++;      break
+      case 'whatsapp_status_delivered': b.delivered++; break
+      case 'whatsapp_status_read':      b.read++;      break
+      case 'whatsapp_status_failed':    b.failed++;    break
+    }
+  }
+
+  for (const row of yConvRows) {
+    if (!(row.occurredAt instanceof Date)) continue
+    const day = toYMD(row.occurredAt)
+    if (!waDailyMap.has(day)) waDailyMap.set(day, zeroBucket())
+    waDailyMap.get(day)!.inbound++
+  }
+
+  const waRates = {
+    entrega: waTotals.sent      > 0 ? waTotals.delivered / waTotals.sent      : 0,
+    leitura: waTotals.delivered > 0 ? waTotals.read      / waTotals.delivered : 0,
+  }
+  const waDaily = Array.from(waDailyMap.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([date, c]) => ({ date, ...c }))
 
   const lastSyncAtMs = ds?.lastSyncAt instanceof Date
     ? ds.lastSyncAt.getTime()
@@ -146,6 +283,11 @@ export async function GET(request: Request) {
     })),
     sentiment,
     recent,
+    whatsapp: {
+      totals: waTotals,
+      rates:  waRates,
+      daily:  waDaily,
+    },
     lastSyncAt: lastSyncAtMs,
   })
 }

--- a/app/api/contacts/route.ts
+++ b/app/api/contacts/route.ts
@@ -1,0 +1,88 @@
+// GET /api/contacts?page=1&limit=50&q=...
+//
+// Response: { items: ContactItem[], total: number, page: number, limit: number }
+//
+// ContactItem: { id, name, phone, email, tags: string[], lastInteractionAt: ms|null, createdAt: ms|null }
+//
+// Requires module 'integration.ycloud-whatsapp'.
+// lastInteractionAt / createdAt: mode:'timestamp' → Drizzle returns Date; .getTime() = epoch ms.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { contacts } from '@/lib/db/schema'
+import { and, desc, eq, like, or, sql } from 'drizzle-orm'
+import { assertEntitlement } from '@/lib/entitlements'
+
+const MAX_LIMIT     = 100
+const DEFAULT_LIMIT = 50
+
+function toMs(v: unknown): number | null {
+  if (v instanceof Date) return v.getTime()
+  if (typeof v === 'number') return v * 1000  // stored as unix seconds when not in timestamp mode
+  return null
+}
+
+function parseTags(raw: string): string[] {
+  try { return JSON.parse(raw) as string[] } catch { return [] }
+}
+
+export async function GET(request: Request) {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { tenantId } = session.user
+  const denied = await assertEntitlement(tenantId, 'integration.ycloud-whatsapp')
+  if (denied) return denied
+
+  const { searchParams } = new URL(request.url)
+  const page  = Math.max(1, parseInt(searchParams.get('page')  ?? '1',                    10))
+  const limit = Math.min(MAX_LIMIT, Math.max(1, parseInt(searchParams.get('limit') ?? String(DEFAULT_LIMIT), 10)))
+  const q     = searchParams.get('q')?.trim() ?? ''
+  const offset = (page - 1) * limit
+
+  const baseWhere = and(
+    eq(contacts.tenantId, tenantId),
+    eq(contacts.source, 'ycloud-whatsapp'),
+  )
+
+  const where = q
+    ? and(baseWhere, or(
+        like(contacts.name,  `%${q}%`),
+        like(contacts.phone, `%${q}%`),
+      ))
+    : baseWhere
+
+  const [{ total }] = await db
+    .select({ total: sql<number>`count(*)` })
+    .from(contacts)
+    .where(where)
+
+  const rows = await db
+    .select({
+      id:                contacts.id,
+      name:              contacts.name,
+      phone:             contacts.phone,
+      email:             contacts.email,
+      tags:              contacts.tags,
+      lastInteractionAt: contacts.lastInteractionAt,
+      createdAt:         contacts.createdAt,
+    })
+    .from(contacts)
+    .where(where)
+    .orderBy(desc(contacts.lastInteractionAt))
+    .limit(limit)
+    .offset(offset)
+
+  const items = rows.map(r => ({
+    id:                r.id,
+    name:              r.name,
+    phone:             r.phone,
+    email:             r.email,
+    tags:              parseTags(r.tags),
+    lastInteractionAt: toMs(r.lastInteractionAt),
+    createdAt:         toMs(r.createdAt),
+  }))
+
+  return NextResponse.json({ items, total: Number(total), page, limit })
+}

--- a/app/api/cron/sync/route.ts
+++ b/app/api/cron/sync/route.ts
@@ -3,6 +3,7 @@ import { db } from '@/lib/db'
 import { dataSources, tenantModules } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { runSync } from '@/lib/sync/runner'
+import { getModuleKeyForProvider } from '@/lib/modules'
 
 export async function GET(request: Request) {
   const authHeader = request.headers.get('authorization')
@@ -32,7 +33,8 @@ export async function GET(request: Request) {
   }> = []
 
   for (const ds of sources) {
-    if (!enabled.has(`${ds.tenantId}:integration.sdr-source`)) {
+    const moduleKey = getModuleKeyForProvider(ds.providerKey)
+    if (!moduleKey || !enabled.has(`${ds.tenantId}:${moduleKey}`)) {
       results.push({
         dataSourceId: ds.id,
         tenantId: ds.tenantId,

--- a/app/api/sdr/source/route.ts
+++ b/app/api/sdr/source/route.ts
@@ -136,6 +136,7 @@ export async function POST(req: NextRequest) {
         lastSyncAt: null,
         lastSyncStatus: null,
         lastSyncError: null,
+        webhookToken: null,
         createdAt: now,
         updatedAt: now,
       }

--- a/app/api/webhooks/ycloud/[token]/route.ts
+++ b/app/api/webhooks/ycloud/[token]/route.ts
@@ -1,0 +1,135 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createHmac, timingSafeEqual } from 'crypto'
+import { and, eq } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { dataSources } from '@/lib/db/schema'
+import { decrypt } from '@/lib/crypto'
+import { normalizeWebhookEvent } from '@/lib/providers/ycloud'
+import { upsertBatch } from '@/lib/sync/runner'
+
+export const dynamic = 'force-dynamic'
+
+const PROVIDER_KEY = 'ycloud-whatsapp'
+
+// ─── Signature helpers ────────────────────────────────────────────────────────
+
+/**
+ * Parses the YCloud-Signature header.
+ * Expected format: "t={unix_timestamp},s={hmac_hex}"
+ */
+function parseSignatureHeader(header: string): { t: string; s: string } | null {
+  const tMatch = /t=([^,]+)/.exec(header)
+  const sMatch = /s=([^,\s]+)/.exec(header)
+  if (!tMatch || !sMatch) return null
+  return { t: tMatch[1], s: sMatch[1] }
+}
+
+/**
+ * Verifies HMAC-SHA256 of "{timestamp}.{rawBody}" against the received hex signature.
+ * Uses timingSafeEqual to prevent timing attacks.
+ *
+ * Size check before timingSafeEqual is mandatory: timingSafeEqual throws if the two
+ * buffers have different lengths, which would produce a 500 on malformed input.
+ */
+function verifySignature(rawBody: string, sigHex: string, timestamp: string, secret: string): boolean {
+  const expected = createHmac('sha256', secret)
+    .update(`${timestamp}.${rawBody}`)
+    .digest('hex')
+  // Compare hex strings as UTF-8 buffers — avoids hex-decode ambiguity and keeps constant time.
+  if (expected.length !== sigHex.length) return false
+  try {
+    return timingSafeEqual(Buffer.from(expected, 'utf8'), Buffer.from(sigHex, 'utf8'))
+  } catch {
+    return false
+  }
+}
+
+// ─── Route handler ────────────────────────────────────────────────────────────
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params
+
+  // Read raw body as text before any parsing — HMAC must be verified over the
+  // exact bytes YCloud sent, not a re-serialised JSON object.
+  const rawBody = await req.text()
+
+  // ── 1. Resolve tenant by webhook token ──────────────────────────────────────
+  const ds = await db
+    .select()
+    .from(dataSources)
+    .where(
+      and(
+        eq(dataSources.webhookToken, token),
+        eq(dataSources.providerKey, PROVIDER_KEY),
+      )
+    )
+    .then(r => r[0])
+
+  if (!ds?.configEnc) {
+    // Return 404 with no detail to avoid confirming which tokens exist.
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  // ── 2. Decrypt config to obtain webhookSecret ────────────────────────────────
+  let webhookSecret: string
+  try {
+    const cfg = JSON.parse(decrypt(ds.configEnc)) as { webhookSecret?: string }
+    if (!cfg.webhookSecret) throw new Error('missing webhookSecret in config')
+    webhookSecret = cfg.webhookSecret
+  } catch (err) {
+    console.error('[ycloud webhook] config decrypt error', err)
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 })
+  }
+
+  // ── 3. Verify YCloud-Signature ───────────────────────────────────────────────
+  //
+  // Timestamp window decision: YCloud's retry schedule is 10s→30s→5m→30m→1h→2h→2h
+  // (up to ~6h total). The docs do NOT state that retries are re-signed with a new
+  // timestamp — they may reuse the original. A strict 5-minute window would silently
+  // drop every retry beyond the first. We intentionally skip timestamp-age rejection:
+  // the HMAC alone is the authenticity gate, and upsertBatch idempotency (deterministic
+  // sourceId) already neutralises replay of the same valid event.
+  //
+  // The entire block is wrapped in try/catch so that any unexpected error from header
+  // parsing or buffer operations returns 401, never 500.
+  try {
+    const sigHeader = req.headers.get('YCloud-Signature')
+    if (!sigHeader) {
+      return NextResponse.json({ error: 'Missing signature' }, { status: 401 })
+    }
+
+    const parsed = parseSignatureHeader(sigHeader)
+    if (!parsed) {
+      return NextResponse.json({ error: 'Malformed signature header' }, { status: 401 })
+    }
+
+    if (!verifySignature(rawBody, parsed.s, parsed.t, webhookSecret)) {
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })
+    }
+  } catch {
+    return NextResponse.json({ error: 'Signature verification failed' }, { status: 401 })
+  }
+
+  // ── 4. Parse, normalize, persist ────────────────────────────────────────────
+  let event: unknown
+  try {
+    event = JSON.parse(rawBody)
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const batch = normalizeWebhookEvent(event, { tenantId: ds.tenantId })
+
+  try {
+    await upsertBatch(batch, ds.tenantId, ds.id, PROVIDER_KEY)
+  } catch (err) {
+    console.error(`[ycloud webhook] upsert failed tenant=${ds.tenantId} source=${ds.id}`, err)
+    // Return 500 so YCloud retries; upsert is idempotent so retries are safe.
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/ycloud/conversations/[sessionId]/route.ts
+++ b/app/api/ycloud/conversations/[sessionId]/route.ts
@@ -1,0 +1,120 @@
+// GET /api/ycloud/conversations/{sessionId}
+//
+// Returns the full message thread for a WhatsApp session, plus the 24h window flag.
+//
+// Response:
+// {
+//   sessionId:      string,
+//   contact:        { name: string | null; phone: string },
+//   inWindow:       boolean,         -- true when free-form text is allowed
+//   windowExpiresAt: number | null,  -- epoch ms = lastInbound + 24h (null if no inbound yet)
+//   messages: [{
+//     id:          string,            -- row id (tenantId:source:ycloudMsgId) — stable unique key
+//     role:        'human'|'ai'|'system',
+//     content:     string,
+//     occurredAt:  number | null,     -- epoch ms
+//     metadata:    Record<string, unknown>,
+//   }],
+// }
+//
+// Next.js 15: params is Promise<{ sessionId: string }> — must be awaited.
+// occurredAt is mode:'timestamp' → Drizzle returns Date; .getTime() = epoch ms.
+// Requires module 'integration.ycloud-whatsapp'.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { conversations, contacts } from '@/lib/db/schema'
+import { and, asc, eq } from 'drizzle-orm'
+import { assertEntitlement } from '@/lib/entitlements'
+
+const MODULE_KEY    = 'integration.ycloud-whatsapp'
+const SOURCE        = 'ycloud-whatsapp'
+const WINDOW_24H_MS = 24 * 60 * 60 * 1000
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { tenantId } = session.user
+  const denied = await assertEntitlement(tenantId, MODULE_KEY)
+  if (denied) return denied
+
+  const { sessionId } = await params
+
+  // ── Fetch all messages for this session, oldest first (chat order) ────────
+
+  const rows = await db
+    .select({
+      id:         conversations.id,
+      role:       conversations.role,
+      content:    conversations.content,
+      occurredAt: conversations.occurredAt,
+      metadata:   conversations.metadata,
+    })
+    .from(conversations)
+    .where(and(
+      eq(conversations.tenantId, tenantId),
+      eq(conversations.source,   SOURCE),
+      eq(conversations.sessionId, sessionId),
+    ))
+    .orderBy(asc(conversations.occurredAt))
+
+  // ── 24h window — same logic as POST /api/ycloud/messages ─────────────────
+  // Find the most recent inbound (role='human') from this session.
+  // Drizzle returns occurredAt as Date; .getTime() = epoch ms.
+
+  let lastInboundMs: number | null = null
+  for (const row of rows) {
+    if (row.role === 'human') {
+      const ms = row.occurredAt instanceof Date ? row.occurredAt.getTime() : null
+      if (ms !== null && (lastInboundMs === null || ms > lastInboundMs)) {
+        lastInboundMs = ms
+      }
+    }
+  }
+
+  const inWindow       = lastInboundMs !== null && (Date.now() - lastInboundMs) <= WINDOW_24H_MS
+  const windowExpiresAt = lastInboundMs !== null ? lastInboundMs + WINDOW_24H_MS : null
+
+  // ── Contact lookup ────────────────────────────────────────────────────────
+  // sessionId = E.164 phone = contacts.externalId for source='ycloud-whatsapp'
+
+  const [contact] = await db
+    .select({ name: contacts.name, phone: contacts.phone })
+    .from(contacts)
+    .where(and(
+      eq(contacts.tenantId,   tenantId),
+      eq(contacts.source,     SOURCE),
+      eq(contacts.externalId, sessionId),
+    ))
+    .limit(1)
+
+  // ── Shape messages ────────────────────────────────────────────────────────
+
+  const messages = rows.map(r => ({
+    id:         r.id,
+    role:       r.role,
+    content:    r.content,
+    occurredAt: r.occurredAt instanceof Date ? r.occurredAt.getTime() : null,
+    metadata:   parseJson(r.metadata),
+  }))
+
+  return NextResponse.json({
+    sessionId,
+    contact: {
+      name:  contact?.name  ?? null,
+      phone: contact?.phone ?? sessionId,  // sessionId is E.164 — safe fallback
+    },
+    inWindow,
+    windowExpiresAt,
+    messages,
+  })
+}
+
+function parseJson(s: string): Record<string, unknown> {
+  try { return JSON.parse(s) as Record<string, unknown> } catch { return {} }
+}

--- a/app/api/ycloud/conversations/route.ts
+++ b/app/api/ycloud/conversations/route.ts
@@ -1,0 +1,143 @@
+// GET /api/ycloud/conversations?page=1&limit=20
+//
+// Lists WhatsApp conversation sessions for the tenant, one row per sessionId.
+// Sessions are sorted by most-recent message DESC and paginated.
+//
+// Response:
+// {
+//   items: [{
+//     sessionId:   string          -- E.164 phone (= externalId in contacts)
+//     name:        string | null   -- from contacts table when available
+//     phone:       string          -- contacts.phone or sessionId when no contact row
+//     lastContact: number | null   -- epoch ms of the most recent message
+//     msgs:        number          -- total messages in session
+//     lastMessage: { content: string; role: 'human' | 'ai' | 'system' }
+//   }],
+//   total:  number,   -- unique session count (capped at ROWS_LIMIT; warn logged if hit)
+//   page:   number,
+//   limit:  number,
+// }
+//
+// occurredAt is mode:'timestamp' → Drizzle returns Date; .getTime() = epoch ms.
+// Requires module 'integration.ycloud-whatsapp'.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { conversations, contacts } from '@/lib/db/schema'
+import { and, desc, eq, inArray } from 'drizzle-orm'
+import { assertEntitlement } from '@/lib/entitlements'
+
+const MODULE_KEY = 'integration.ycloud-whatsapp'
+const SOURCE     = 'ycloud-whatsapp'
+const MAX_LIMIT  = 50
+const ROWS_LIMIT = 10_000    // cap on raw conversation rows fetched for JS dedup
+
+export async function GET(request: Request) {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { tenantId } = session.user
+  const denied = await assertEntitlement(tenantId, MODULE_KEY)
+  if (denied) return denied
+
+  const { searchParams } = new URL(request.url)
+  const page  = Math.max(1, parseInt(searchParams.get('page')  ?? '1',  10))
+  const limit = Math.min(MAX_LIMIT, Math.max(1, parseInt(searchParams.get('limit') ?? '20', 10)))
+
+  // ── Fetch all conversation rows, newest first ─────────────────────────────
+  // Drizzle returns occurredAt as Date (mode:'timestamp' stores INTEGER seconds,
+  // converts to Date on read). First occurrence per sessionId in DESC order = latest.
+
+  const rows = await db
+    .select({
+      sessionId:  conversations.sessionId,
+      role:       conversations.role,
+      content:    conversations.content,
+      occurredAt: conversations.occurredAt,
+    })
+    .from(conversations)
+    .where(and(
+      eq(conversations.tenantId, tenantId),
+      eq(conversations.source,   SOURCE),
+    ))
+    .orderBy(desc(conversations.occurredAt))
+    .limit(ROWS_LIMIT)
+
+  if (rows.length === ROWS_LIMIT) {
+    console.warn(`[ycloud conversations list] cap de ${ROWS_LIMIT} rows atingido; totais podem estar subestimados`)
+  }
+
+  // ── Dedup by sessionId in JS — same pattern as /api/bi/sdr ───────────────
+  // Because rows are DESC, the first occurrence per sessionId is the most recent
+  // message → captured as lastMessage. Subsequent rows only increment msgs.
+
+  interface SessionEntry {
+    sessionId:   string
+    lastContact: number | null
+    msgs:        number
+    lastMessage: { content: string; role: string }
+  }
+
+  const sessionMap = new Map<string, SessionEntry>()
+  for (const row of rows) {
+    const ms = row.occurredAt instanceof Date ? row.occurredAt.getTime() : null
+    const ex = sessionMap.get(row.sessionId)
+    if (!ex) {
+      sessionMap.set(row.sessionId, {
+        sessionId:   row.sessionId,
+        lastContact: ms,
+        msgs:        1,
+        lastMessage: { content: row.content, role: row.role },
+      })
+    } else {
+      ex.msgs++
+      if (ms && (!ex.lastContact || ms > ex.lastContact)) ex.lastContact = ms
+    }
+  }
+
+  // ── Sort DESC by lastContact, paginate ────────────────────────────────────
+
+  const sorted = Array.from(sessionMap.values())
+    .sort((a, b) => (b.lastContact ?? 0) - (a.lastContact ?? 0))
+
+  const total      = sorted.length
+  const pageItems  = sorted.slice((page - 1) * limit, page * limit)
+
+  // ── Contact lookup for the current page ──────────────────────────────────
+  // sessionId = E.164 phone = contacts.externalId for source='ycloud-whatsapp'
+
+  const pageIds = pageItems.map(s => s.sessionId)
+  const contactRows = pageIds.length > 0
+    ? await db
+        .select({
+          externalId: contacts.externalId,
+          name:       contacts.name,
+          phone:      contacts.phone,
+        })
+        .from(contacts)
+        .where(and(
+          eq(contacts.tenantId, tenantId),
+          eq(contacts.source,   SOURCE),
+          inArray(contacts.externalId, pageIds),
+        ))
+    : []
+
+  const contactMap = new Map(contactRows.map(c => [c.externalId, c]))
+
+  // ── Shape response ────────────────────────────────────────────────────────
+
+  const items = pageItems.map(s => {
+    const c = contactMap.get(s.sessionId)
+    return {
+      sessionId:   s.sessionId,
+      name:        c?.name  ?? null,
+      phone:       c?.phone ?? s.sessionId,   // sessionId = E.164 phone when no contact row
+      lastContact: s.lastContact,
+      msgs:        s.msgs,
+      lastMessage: s.lastMessage,
+    }
+  })
+
+  return NextResponse.json({ items, total, page, limit })
+}

--- a/app/api/ycloud/messages/route.ts
+++ b/app/api/ycloud/messages/route.ts
@@ -1,0 +1,215 @@
+// POST /api/ycloud/messages
+//
+// Sends a WhatsApp message (text or template) and records the outbound
+// conversation as role='ai' in Turso (idempotent via YCloud message id).
+//
+// Request body (discriminated on type):
+//   { to: string; type: 'text'; body: string }
+//   { to: string; type: 'template'; templateName: string; languageCode: string; components?: unknown[] }
+//
+// 24-hour window rule (WhatsApp policy):
+//   Free-form text is only allowed within 24h of the customer's last inbound message.
+//   Outside that window, or when no inbound message exists for the session, only
+//   templates are permitted. Attempting to send text outside the window returns 422.
+//
+// Response on success: { ok: true, messageId: string }
+// Requires module 'integration.ycloud-whatsapp'.
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { dataSources, conversations } from '@/lib/db/schema'
+import { and, desc, eq } from 'drizzle-orm'
+import { decrypt } from '@/lib/crypto'
+import { assertEntitlement } from '@/lib/entitlements'
+import { yCloudProvider, sendWhatsappMessage } from '@/lib/providers/ycloud'
+import type { SendWhatsappParams } from '@/lib/providers/ycloud'
+import { upsertBatch } from '@/lib/sync/runner'
+
+const PROVIDER_KEY = 'ycloud-whatsapp'
+const MODULE_KEY   = 'integration.ycloud-whatsapp'
+
+// WhatsApp policy: free-form text window (ms)
+const WINDOW_24H_MS = 24 * 60 * 60 * 1000
+
+export async function POST(req: NextRequest) {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { tenantId } = session.user
+  const denied = await assertEntitlement(tenantId, MODULE_KEY)
+  if (denied) return denied
+
+  // ── Parse body ──────────────────────────────────────────────────────────────
+
+  let raw: unknown
+  try {
+    raw = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  }
+  if (!raw || typeof raw !== 'object') {
+    return NextResponse.json({ error: 'body_required' }, { status: 400 })
+  }
+
+  const b = raw as Record<string, unknown>
+  const to   = typeof b.to   === 'string' ? b.to.trim()   : ''
+  const type = b.type
+
+  if (!to) {
+    return NextResponse.json(
+      { error: 'to_required', message: '"to" (E.164 phone) é obrigatório' },
+      { status: 400 },
+    )
+  }
+  if (type !== 'text' && type !== 'template') {
+    return NextResponse.json(
+      { error: 'type_invalid', message: '"type" deve ser "text" ou "template"' },
+      { status: 400 },
+    )
+  }
+  if (type === 'text') {
+    if (!b.body || typeof b.body !== 'string' || !(b.body as string).trim()) {
+      return NextResponse.json(
+        { error: 'body_required', message: '"body" é obrigatório para type=text' },
+        { status: 400 },
+      )
+    }
+  }
+  if (type === 'template') {
+    if (!b.templateName || typeof b.templateName !== 'string') {
+      return NextResponse.json(
+        { error: 'templateName_required', message: '"templateName" é obrigatório para type=template' },
+        { status: 400 },
+      )
+    }
+    if (!b.languageCode || typeof b.languageCode !== 'string') {
+      return NextResponse.json(
+        { error: 'languageCode_required', message: '"languageCode" é obrigatório para type=template' },
+        { status: 400 },
+      )
+    }
+  }
+
+  // ── Load & decrypt config ───────────────────────────────────────────────────
+
+  const row = await db
+    .select()
+    .from(dataSources)
+    .where(and(
+      eq(dataSources.tenantId, tenantId),
+      eq(dataSources.providerKey, PROVIDER_KEY),
+    ))
+    .then(r => r[0])
+
+  if (!row?.configEnc) {
+    return NextResponse.json({ error: 'integration_not_configured' }, { status: 404 })
+  }
+
+  let cfg: ReturnType<typeof yCloudProvider.parseConfig>
+  try {
+    cfg = yCloudProvider.parseConfig(JSON.parse(decrypt(row.configEnc)))
+  } catch (err) {
+    return NextResponse.json(
+      { error: 'config_invalid', message: (err as Error).message },
+      { status: 500 },
+    )
+  }
+
+  // ── 24-hour window check (text-only) ───────────────────────────────────────
+  //
+  // occurredAt is mode:'timestamp' → Drizzle stores as INTEGER seconds,
+  // returns Date objects on read. `.getTime()` gives epoch ms.
+  // We sort descending and take the single latest inbound row to avoid a
+  // MAX() aggregate that would bypass Drizzle's timestamp conversion.
+
+  if (type === 'text') {
+    const [latest] = await db
+      .select({ occurredAt: conversations.occurredAt })
+      .from(conversations)
+      .where(and(
+        eq(conversations.tenantId, tenantId),
+        eq(conversations.source,   'ycloud-whatsapp'),
+        eq(conversations.sessionId, to),
+        eq(conversations.role,      'human'),
+      ))
+      .orderBy(desc(conversations.occurredAt))
+      .limit(1)
+
+    // epoch ms of the last inbound message from this customer
+    const lastInboundMs = latest?.occurredAt instanceof Date
+      ? latest.occurredAt.getTime()
+      : null
+
+    const inWindow = lastInboundMs != null && (Date.now() - lastInboundMs) <= WINDOW_24H_MS
+
+    if (!inWindow) {
+      return NextResponse.json(
+        {
+          error:   'fora_da_janela_24h',
+          message: 'Fora da janela de 24h. Use um template aprovado.',
+        },
+        { status: 422 },
+      )
+    }
+  }
+
+  // ── Build send params & dispatch ────────────────────────────────────────────
+
+  const sendParams: SendWhatsappParams = type === 'text'
+    ? { to, type: 'text', body: (b.body as string).trim() }
+    : {
+        to,
+        type:         'template',
+        templateName: b.templateName as string,
+        languageCode: b.languageCode as string,
+        components:   Array.isArray(b.components) ? b.components : undefined,
+      }
+
+  let messageId: string
+  try {
+    const result = await sendWhatsappMessage(cfg, sendParams)
+    messageId = result.id
+  } catch (err) {
+    return NextResponse.json(
+      { error: 'ycloud_error', message: (err as Error).message },
+      { status: 502 },
+    )
+  }
+
+  // ── Record outbound as conversation role='ai' ───────────────────────────────
+  //
+  // sourceId = YCloud message id → deterministic row id (tenantId:source:messageId).
+  // Idempotent: a duplicate call with the same messageId (won't happen via YCloud,
+  // but possible in retries) will onConflictDoUpdate instead of inserting a new row.
+  // When YCloud fires whatsapp.message.updated webhooks for this message,
+  // those go into the events table under the same id — no collision.
+
+  const content = type === 'text'
+    ? (b.body as string).trim()
+    : `[template:${b.templateName as string}]`
+
+  const metadata: Record<string, unknown> = { type }
+  if (type === 'template') {
+    metadata.templateName = b.templateName
+    metadata.languageCode = b.languageCode
+  }
+
+  await upsertBatch(
+    {
+      conversations: [{
+        sourceId:   messageId,
+        sessionId:  to,
+        role:       'ai',
+        content,
+        occurredAt: Date.now(),
+        metadata,
+      }],
+    },
+    tenantId,
+    row.id,
+    'ycloud-whatsapp',
+  )
+
+  return NextResponse.json({ ok: true, messageId })
+}

--- a/app/api/ycloud/source/route.ts
+++ b/app/api/ycloud/source/route.ts
@@ -1,0 +1,179 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { dataSources } from '@/lib/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { encrypt, decrypt } from '@/lib/crypto'
+import { randomUUID, randomBytes } from 'crypto'
+import { assertEntitlement } from '@/lib/entitlements'
+import { getProvider } from '@/lib/providers/registry'
+import { runBackfill } from '@/lib/sync/runner'
+import { waitUntil } from '@vercel/functions'
+
+const PROVIDER_KEY = 'ycloud-whatsapp'
+const MODULE_KEY   = 'integration.ycloud-whatsapp'
+
+function getBaseUrl(): string {
+  return process.env.APP_URL || process.env.NEXTAUTH_URL || 'http://localhost:3000'
+}
+
+function buildWebhookUrl(token: string): string {
+  return `${getBaseUrl()}/api/webhooks/ycloud/${token}`
+}
+
+function maskApiKey(apiKey: string): string {
+  if (apiKey.length <= 4) return '••••'
+  return `••••${apiKey.slice(-4)}`
+}
+
+export async function GET() {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const denied = await assertEntitlement(session.user.tenantId, MODULE_KEY)
+  if (denied) return denied
+
+  const row = await db
+    .select()
+    .from(dataSources)
+    .where(
+      and(
+        eq(dataSources.tenantId, session.user.tenantId),
+        eq(dataSources.providerKey, PROVIDER_KEY)
+      )
+    )
+    .then(r => r[0])
+
+  if (!row) return NextResponse.json({ configured: false })
+
+  let apiKeyMasked: string | null = null
+  let fromPhone:    string | null = null
+  if (row.configEnc) {
+    try {
+      const cfg = JSON.parse(decrypt(row.configEnc)) as { apiKey?: string; fromPhone?: string }
+      if (cfg.apiKey)    apiKeyMasked = maskApiKey(cfg.apiKey)
+      if (cfg.fromPhone) fromPhone    = cfg.fromPhone
+    } catch {
+      // keep nulls — config is unreadable but don't surface crypto errors
+    }
+  }
+
+  const webhookUrl = row.webhookToken ? buildWebhookUrl(row.webhookToken) : null
+
+  return NextResponse.json({
+    configured: true,
+    status:          row.status,
+    lastSyncAt:      row.lastSyncAt ? row.lastSyncAt.getTime() : null,
+    lastSyncStatus:  row.lastSyncStatus,
+    lastSyncError:   row.lastSyncError,
+    apiKeyMasked,
+    fromPhone,
+    webhookUrl,
+  })
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const denied = await assertEntitlement(session.user.tenantId, MODULE_KEY)
+  if (denied) return denied
+
+  const body = await req.json()
+  const { apiKey, webhookSecret, fromPhone } = body as { apiKey?: string; webhookSecret?: string; fromPhone?: string }
+
+  const provider = getProvider(PROVIDER_KEY)
+  if (!provider) {
+    return NextResponse.json({ error: 'Provider não encontrado' }, { status: 500 })
+  }
+
+  try {
+    provider.parseConfig({ apiKey, webhookSecret, fromPhone })
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ error: msg }, { status: 400 })
+  }
+
+  try {
+    const configEnc = encrypt(JSON.stringify({ apiKey, webhookSecret, fromPhone }))
+    const now = new Date()
+    const tenantId = session.user.tenantId
+
+    const existing = await db
+      .select()
+      .from(dataSources)
+      .where(
+        and(
+          eq(dataSources.tenantId, tenantId),
+          eq(dataSources.providerKey, PROVIDER_KEY)
+        )
+      )
+      .then(r => r[0])
+
+    let webhookToken: string
+    let savedRow: typeof dataSources.$inferSelect
+
+    if (existing) {
+      await db
+        .update(dataSources)
+        .set({ configEnc, status: 'connected', updatedAt: now })
+        .where(eq(dataSources.id, existing.id))
+
+      // Preserve the existing token — regenerating would break the URL already
+      // registered in the YCloud dashboard.
+      webhookToken = existing.webhookToken ?? randomBytes(32).toString('hex')
+
+      if (!existing.webhookToken) {
+        await db
+          .update(dataSources)
+          .set({ webhookToken })
+          .where(eq(dataSources.id, existing.id))
+      }
+
+      savedRow = { ...existing, configEnc, status: 'connected', webhookToken, updatedAt: now }
+    } else {
+      webhookToken = randomBytes(32).toString('hex')
+      const insertId = randomUUID()
+      await db.insert(dataSources).values({
+        id:           insertId,
+        tenantId,
+        providerKey:  PROVIDER_KEY,
+        label:        'YCloud (WhatsApp)',
+        configEnc,
+        status:       'connected',
+        webhookToken,
+        createdAt:    now,
+        updatedAt:    now,
+      })
+      savedRow = {
+        id:             insertId,
+        tenantId,
+        providerKey:    PROVIDER_KEY,
+        label:          'YCloud (WhatsApp)',
+        configEnc,
+        status:         'connected',
+        syncCursor:     null,
+        lastSyncAt:     null,
+        lastSyncStatus: null,
+        lastSyncError:  null,
+        webhookToken,
+        createdAt:      now,
+        updatedAt:      now,
+      }
+    }
+
+    try {
+      waitUntil(runBackfill(savedRow).catch(err => console.error('[ycloud backfill]', err)))
+    } catch (err) {
+      console.error('[ycloud backfill schedule]', err)
+    }
+
+    return NextResponse.json({ ok: true, webhookUrl: buildWebhookUrl(webhookToken) })
+  } catch (err) {
+    console.error('[ycloud source POST]', err)
+    return NextResponse.json(
+      { ok: false, error: String((err as Error)?.message ?? err) },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/ycloud/source/test/route.ts
+++ b/app/api/ycloud/source/test/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { assertEntitlement } from '@/lib/entitlements'
+import { getProvider } from '@/lib/providers/registry'
+
+const PROVIDER_KEY = 'ycloud-whatsapp'
+
+export async function POST(req: NextRequest) {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const denied = await assertEntitlement(session.user.tenantId, 'integration.ycloud-whatsapp')
+  if (denied) return denied
+
+  const body = await req.json()
+  const { apiKey, webhookSecret } = body as { apiKey?: string; webhookSecret?: string }
+
+  if (!apiKey || typeof apiKey !== 'string') {
+    return NextResponse.json({ valid: false, error: 'apiKey é obrigatório' })
+  }
+  if (!webhookSecret || typeof webhookSecret !== 'string') {
+    return NextResponse.json({ valid: false, error: 'webhookSecret é obrigatório' })
+  }
+
+  const provider = getProvider(PROVIDER_KEY)
+  if (!provider) {
+    return NextResponse.json({ valid: false, error: 'Provider não encontrado' })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let cfg: any
+  try {
+    cfg = provider.parseConfig({ apiKey, webhookSecret })
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ valid: false, error: msg })
+  }
+
+  try {
+    const result = await provider.testConnection(cfg)
+    return NextResponse.json({ valid: result.ok, error: result.message })
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ valid: false, error: msg })
+  }
+}

--- a/app/api/ycloud/templates/route.ts
+++ b/app/api/ycloud/templates/route.ts
@@ -1,0 +1,62 @@
+// GET /api/ycloud/templates
+//
+// Returns the full WhatsApp template list for this tenant's YCloud account.
+// Response: { templates: WhatsappTemplate[] }
+//
+// Each template: { name, language, category?, status, components? }
+// status includes 'approved' | 'rejected' | 'pending' — UI should filter.
+// Requires module 'integration.ycloud-whatsapp'.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { dataSources } from '@/lib/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { decrypt } from '@/lib/crypto'
+import { assertEntitlement } from '@/lib/entitlements'
+import { yCloudProvider, listWhatsappTemplates } from '@/lib/providers/ycloud'
+
+const PROVIDER_KEY = 'ycloud-whatsapp'
+const MODULE_KEY   = 'integration.ycloud-whatsapp'
+
+export async function GET() {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { tenantId } = session.user
+  const denied = await assertEntitlement(tenantId, MODULE_KEY)
+  if (denied) return denied
+
+  const row = await db
+    .select()
+    .from(dataSources)
+    .where(and(
+      eq(dataSources.tenantId, tenantId),
+      eq(dataSources.providerKey, PROVIDER_KEY),
+    ))
+    .then(r => r[0])
+
+  if (!row?.configEnc) {
+    return NextResponse.json({ error: 'integration_not_configured' }, { status: 404 })
+  }
+
+  let cfg: ReturnType<typeof yCloudProvider.parseConfig>
+  try {
+    cfg = yCloudProvider.parseConfig(JSON.parse(decrypt(row.configEnc)))
+  } catch (err) {
+    return NextResponse.json(
+      { error: 'config_invalid', message: (err as Error).message },
+      { status: 500 },
+    )
+  }
+
+  try {
+    const templates = await listWhatsappTemplates(cfg)
+    return NextResponse.json({ templates })
+  } catch (err) {
+    return NextResponse.json(
+      { error: 'ycloud_error', message: (err as Error).message },
+      { status: 502 },
+    )
+  }
+}

--- a/drizzle/0005_nasty_proudstar.sql
+++ b/drizzle/0005_nasty_proudstar.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `data_sources` ADD `webhook_token` text;--> statement-breakpoint
+CREATE UNIQUE INDEX `data_sources_webhook_token_idx` ON `data_sources` (`webhook_token`);

--- a/drizzle/0006_spooky_invaders.sql
+++ b/drizzle/0006_spooky_invaders.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `contacts` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tenant_id` text NOT NULL,
+	`data_source_id` text,
+	`source` text NOT NULL,
+	`external_id` text NOT NULL,
+	`name` text,
+	`phone` text,
+	`email` text,
+	`tags` text DEFAULT '[]' NOT NULL,
+	`last_interaction_at` integer,
+	`metadata` text DEFAULT '{}' NOT NULL,
+	`extra` text DEFAULT '{}' NOT NULL,
+	`created_at` integer,
+	`synced_at` integer,
+	FOREIGN KEY (`tenant_id`) REFERENCES `tenants`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`data_source_id`) REFERENCES `data_sources`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `contacts_lookup_idx` ON `contacts` (`tenant_id`,`source`,`last_interaction_at`);

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,2415 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e083e876-ecf7-4588-90b8-ff077ec54eb2",
+  "prevId": "b7c855bc-6221-4521-94f4-027a75e76dd4",
+  "tables": {
+    "ad_ads": {
+      "name": "ad_ads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_adset_id": {
+          "name": "external_adset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_campaign_id": {
+          "name": "external_campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ad_ads_tenant_id_tenants_id_fk": {
+          "name": "ad_ads_tenant_id_tenants_id_fk",
+          "tableFrom": "ad_ads",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ad_adsets": {
+      "name": "ad_adsets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_campaign_id": {
+          "name": "external_campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_budget": {
+          "name": "daily_budget",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ad_adsets_tenant_id_tenants_id_fk": {
+          "name": "ad_adsets_tenant_id_tenants_id_fk",
+          "tableFrom": "ad_adsets",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ad_campaigns": {
+      "name": "ad_campaigns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_budget": {
+          "name": "daily_budget",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lifetime_budget": {
+          "name": "lifetime_budget",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ad_campaigns_tenant_id_tenants_id_fk": {
+          "name": "ad_campaigns_tenant_id_tenants_id_fk",
+          "tableFrom": "ad_campaigns",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ad_insights": {
+      "name": "ad_insights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_ad_id": {
+          "name": "external_ad_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_adset_id": {
+          "name": "external_adset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_campaign_id": {
+          "name": "external_campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impressions": {
+          "name": "impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "spend": {
+          "name": "spend",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reach": {
+          "name": "reach",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "conversions": {
+          "name": "conversions",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "conversion_value": {
+          "name": "conversion_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "ctr": {
+          "name": "ctr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cpm": {
+          "name": "cpm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "roas": {
+          "name": "roas",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ad_insights_tenant_id_tenants_id_fk": {
+          "name": "ad_insights_tenant_id_tenants_id_fk",
+          "tableFrom": "ad_insights",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_settings": {
+      "name": "ai_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_enc": {
+          "name": "api_key_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'claude-haiku-4-5-20251001'"
+        },
+        "monthly_budget_brl": {
+          "name": "monthly_budget_brl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cached_spend_usd": {
+          "name": "cached_spend_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "budget_month": {
+          "name": "budget_month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_settings_tenant_id_unique": {
+          "name": "ai_settings_tenant_id_unique",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ai_settings_tenant_id_tenants_id_fk": {
+          "name": "ai_settings_tenant_id_tenants_id_fk",
+          "tableFrom": "ai_settings",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_usage_logs": {
+      "name": "ai_usage_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'chat'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_usage_logs_tenant_id_tenants_id_fk": {
+          "name": "ai_usage_logs_tenant_id_tenants_id_fk",
+          "tableFrom": "ai_usage_logs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "campaign_settings": {
+      "name": "campaign_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'sdr-n8n'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "campaign_settings_tenant_source_unq": {
+          "name": "campaign_settings_tenant_source_unq",
+          "columns": [
+            "tenant_id",
+            "source"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "campaign_settings_tenant_id_tenants_id_fk": {
+          "name": "campaign_settings_tenant_id_tenants_id_fk",
+          "tableFrom": "campaign_settings",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "conversations_session_idx": {
+          "name": "conversations_session_idx",
+          "columns": [
+            "tenant_id",
+            "source",
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "conversations_tenant_id_tenants_id_fk": {
+          "name": "conversations_tenant_id_tenants_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversations_data_source_id_data_sources_id_fk": {
+          "name": "conversations_data_source_id_data_sources_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "data_sources": {
+      "name": "data_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_key": {
+          "name": "provider_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "config_enc": {
+          "name": "config_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "sync_cursor": {
+          "name": "sync_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webhook_token": {
+          "name": "webhook_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "data_sources_tenant_provider_idx": {
+          "name": "data_sources_tenant_provider_idx",
+          "columns": [
+            "tenant_id",
+            "provider_key"
+          ],
+          "isUnique": false
+        },
+        "data_sources_webhook_token_idx": {
+          "name": "data_sources_webhook_token_idx",
+          "columns": [
+            "webhook_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "data_sources_tenant_id_tenants_id_fk": {
+          "name": "data_sources_tenant_id_tenants_id_fk",
+          "tableFrom": "data_sources",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "extra": {
+          "name": "extra",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_lookup_idx": {
+          "name": "events_lookup_idx",
+          "columns": [
+            "tenant_id",
+            "source",
+            "occurred_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_tenant_id_tenants_id_fk": {
+          "name": "events_tenant_id_tenants_id_fk",
+          "tableFrom": "events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_data_source_id_data_sources_id_fk": {
+          "name": "events_data_source_id_data_sources_id_fk",
+          "tableFrom": "events",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "funnel_snapshots": {
+      "name": "funnel_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_key": {
+          "name": "stage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_name": {
+          "name": "stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "extra": {
+          "name": "extra",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "funnel_snapshots_period_idx": {
+          "name": "funnel_snapshots_period_idx",
+          "columns": [
+            "tenant_id",
+            "source",
+            "period"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "funnel_snapshots_tenant_id_tenants_id_fk": {
+          "name": "funnel_snapshots_tenant_id_tenants_id_fk",
+          "tableFrom": "funnel_snapshots",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "funnel_snapshots_data_source_id_data_sources_id_fk": {
+          "name": "funnel_snapshots_data_source_id_data_sources_id_fk",
+          "tableFrom": "funnel_snapshots",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "integrations": {
+      "name": "integrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'kommo'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_domain": {
+          "name": "account_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_pipeline_id": {
+          "name": "selected_pipeline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_pipeline_name": {
+          "name": "selected_pipeline_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "integrations_tenant_id_tenants_id_fk": {
+          "name": "integrations_tenant_id_tenants_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lead_extras": {
+      "name": "lead_extras",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'normal'"
+        },
+        "custom_fields": {
+          "name": "custom_fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "lead_extras_lead_id_unique": {
+          "name": "lead_extras_lead_id_unique",
+          "columns": [
+            "lead_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "lead_extras_lead_id_leads_id_fk": {
+          "name": "lead_extras_lead_id_leads_id_fk",
+          "tableFrom": "lead_extras",
+          "tableTo": "leads",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lead_extras_tenant_id_tenants_id_fk": {
+          "name": "lead_extras_tenant_id_tenants_id_fk",
+          "tableFrom": "lead_extras",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "leads": {
+      "name": "leads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kommo_id": {
+          "name": "kommo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responsible_name": {
+          "name": "responsible_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'—'"
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "loss_reason": {
+          "name": "loss_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leads_tenant_id_tenants_id_fk": {
+          "name": "leads_tenant_id_tenants_id_fk",
+          "tableFrom": "leads",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "leads_pipeline_id_pipelines_id_fk": {
+          "name": "leads_pipeline_id_pipelines_id_fk",
+          "tableFrom": "leads",
+          "tableTo": "pipelines",
+          "columnsFrom": [
+            "pipeline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "leads_stage_id_stages_id_fk": {
+          "name": "leads_stage_id_stages_id_fk",
+          "tableFrom": "leads",
+          "tableTo": "stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metrics": {
+      "name": "metrics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric_key": {
+          "name": "metric_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "extra": {
+          "name": "extra",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "metrics_lookup_idx": {
+          "name": "metrics_lookup_idx",
+          "columns": [
+            "tenant_id",
+            "source",
+            "metric_key",
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "metrics_tenant_id_tenants_id_fk": {
+          "name": "metrics_tenant_id_tenants_id_fk",
+          "tableFrom": "metrics",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "metrics_data_source_id_data_sources_id_fk": {
+          "name": "metrics_data_source_id_data_sources_id_fk",
+          "tableFrom": "metrics",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "password_reset_tokens_token_unique": {
+          "name": "password_reset_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pipelines": {
+      "name": "pipelines",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kommo_id": {
+          "name": "kommo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pipelines_tenant_id_tenants_id_fk": {
+          "name": "pipelines_tenant_id_tenants_id_fk",
+          "tableFrom": "pipelines",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plan_modules": {
+      "name": "plan_modules",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "module_key": {
+          "name": "module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_modules_plan_id_plans_id_fk": {
+          "name": "plan_modules_plan_id_plans_id_fk",
+          "tableFrom": "plan_modules",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "plan_modules_plan_id_module_key_pk": {
+          "columns": [
+            "plan_id",
+            "module_key"
+          ],
+          "name": "plan_modules_plan_id_module_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plans": {
+      "name": "plans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_teams": {
+      "name": "sales_teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#FFB400'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sales_teams_tenant_id_tenants_id_fk": {
+          "name": "sales_teams_tenant_id_tenants_id_fk",
+          "tableFrom": "sales_teams",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stages": {
+      "name": "stages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kommo_id": {
+          "name": "kommo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#AAAAAA'"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stages_pipeline_id_pipelines_id_fk": {
+          "name": "stages_pipeline_id_pipelines_id_fk",
+          "tableFrom": "stages",
+          "tableTo": "pipelines",
+          "columnsFrom": [
+            "pipeline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_members": {
+      "name": "team_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responsible_name": {
+          "name": "responsible_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_team_id_sales_teams_id_fk": {
+          "name": "team_members_team_id_sales_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "sales_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_tenant_id_tenants_id_fk": {
+          "name": "team_members_tenant_id_tenants_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_modules": {
+      "name": "tenant_modules",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "module_key": {
+          "name": "module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_modules_tenant_id_tenants_id_fk": {
+          "name": "tenant_modules_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_modules",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tenant_modules_tenant_id_module_key_pk": {
+          "columns": [
+            "tenant_id",
+            "module_key"
+          ],
+          "name": "tenant_modules_tenant_id_module_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenants": {
+      "name": "tenants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#FFB400'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "avatar_color": {
+          "name": "avatar_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#FFB400'"
+        },
+        "avatar_bg": {
+          "name": "avatar_bg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#121316'"
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "users_tenant_id_tenants_id_fk": {
+          "name": "users_tenant_id_tenants_id_fk",
+          "tableFrom": "users",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,2563 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9381c631-6580-48ed-a467-9b0f91adee74",
+  "prevId": "e083e876-ecf7-4588-90b8-ff077ec54eb2",
+  "tables": {
+    "ad_ads": {
+      "name": "ad_ads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_adset_id": {
+          "name": "external_adset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_campaign_id": {
+          "name": "external_campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ad_ads_tenant_id_tenants_id_fk": {
+          "name": "ad_ads_tenant_id_tenants_id_fk",
+          "tableFrom": "ad_ads",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ad_adsets": {
+      "name": "ad_adsets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_campaign_id": {
+          "name": "external_campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_budget": {
+          "name": "daily_budget",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ad_adsets_tenant_id_tenants_id_fk": {
+          "name": "ad_adsets_tenant_id_tenants_id_fk",
+          "tableFrom": "ad_adsets",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ad_campaigns": {
+      "name": "ad_campaigns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daily_budget": {
+          "name": "daily_budget",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lifetime_budget": {
+          "name": "lifetime_budget",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ad_campaigns_tenant_id_tenants_id_fk": {
+          "name": "ad_campaigns_tenant_id_tenants_id_fk",
+          "tableFrom": "ad_campaigns",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ad_insights": {
+      "name": "ad_insights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_ad_id": {
+          "name": "external_ad_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_adset_id": {
+          "name": "external_adset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_campaign_id": {
+          "name": "external_campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impressions": {
+          "name": "impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "spend": {
+          "name": "spend",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reach": {
+          "name": "reach",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "conversions": {
+          "name": "conversions",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "conversion_value": {
+          "name": "conversion_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "ctr": {
+          "name": "ctr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cpm": {
+          "name": "cpm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "roas": {
+          "name": "roas",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ad_insights_tenant_id_tenants_id_fk": {
+          "name": "ad_insights_tenant_id_tenants_id_fk",
+          "tableFrom": "ad_insights",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_settings": {
+      "name": "ai_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_enc": {
+          "name": "api_key_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'claude-haiku-4-5-20251001'"
+        },
+        "monthly_budget_brl": {
+          "name": "monthly_budget_brl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cached_spend_usd": {
+          "name": "cached_spend_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "budget_month": {
+          "name": "budget_month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_settings_tenant_id_unique": {
+          "name": "ai_settings_tenant_id_unique",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ai_settings_tenant_id_tenants_id_fk": {
+          "name": "ai_settings_tenant_id_tenants_id_fk",
+          "tableFrom": "ai_settings",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_usage_logs": {
+      "name": "ai_usage_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'chat'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_usage_logs_tenant_id_tenants_id_fk": {
+          "name": "ai_usage_logs_tenant_id_tenants_id_fk",
+          "tableFrom": "ai_usage_logs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "campaign_settings": {
+      "name": "campaign_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'sdr-n8n'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "campaign_settings_tenant_source_unq": {
+          "name": "campaign_settings_tenant_source_unq",
+          "columns": [
+            "tenant_id",
+            "source"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "campaign_settings_tenant_id_tenants_id_fk": {
+          "name": "campaign_settings_tenant_id_tenants_id_fk",
+          "tableFrom": "campaign_settings",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contacts": {
+      "name": "contacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "last_interaction_at": {
+          "name": "last_interaction_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "extra": {
+          "name": "extra",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "contacts_lookup_idx": {
+          "name": "contacts_lookup_idx",
+          "columns": [
+            "tenant_id",
+            "source",
+            "last_interaction_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contacts_tenant_id_tenants_id_fk": {
+          "name": "contacts_tenant_id_tenants_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contacts_data_source_id_data_sources_id_fk": {
+          "name": "contacts_data_source_id_data_sources_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "conversations_session_idx": {
+          "name": "conversations_session_idx",
+          "columns": [
+            "tenant_id",
+            "source",
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "conversations_tenant_id_tenants_id_fk": {
+          "name": "conversations_tenant_id_tenants_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversations_data_source_id_data_sources_id_fk": {
+          "name": "conversations_data_source_id_data_sources_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "data_sources": {
+      "name": "data_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_key": {
+          "name": "provider_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "config_enc": {
+          "name": "config_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "sync_cursor": {
+          "name": "sync_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webhook_token": {
+          "name": "webhook_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "data_sources_tenant_provider_idx": {
+          "name": "data_sources_tenant_provider_idx",
+          "columns": [
+            "tenant_id",
+            "provider_key"
+          ],
+          "isUnique": false
+        },
+        "data_sources_webhook_token_idx": {
+          "name": "data_sources_webhook_token_idx",
+          "columns": [
+            "webhook_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "data_sources_tenant_id_tenants_id_fk": {
+          "name": "data_sources_tenant_id_tenants_id_fk",
+          "tableFrom": "data_sources",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "extra": {
+          "name": "extra",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_lookup_idx": {
+          "name": "events_lookup_idx",
+          "columns": [
+            "tenant_id",
+            "source",
+            "occurred_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_tenant_id_tenants_id_fk": {
+          "name": "events_tenant_id_tenants_id_fk",
+          "tableFrom": "events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_data_source_id_data_sources_id_fk": {
+          "name": "events_data_source_id_data_sources_id_fk",
+          "tableFrom": "events",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "funnel_snapshots": {
+      "name": "funnel_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_key": {
+          "name": "stage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_name": {
+          "name": "stage_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "extra": {
+          "name": "extra",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "funnel_snapshots_period_idx": {
+          "name": "funnel_snapshots_period_idx",
+          "columns": [
+            "tenant_id",
+            "source",
+            "period"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "funnel_snapshots_tenant_id_tenants_id_fk": {
+          "name": "funnel_snapshots_tenant_id_tenants_id_fk",
+          "tableFrom": "funnel_snapshots",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "funnel_snapshots_data_source_id_data_sources_id_fk": {
+          "name": "funnel_snapshots_data_source_id_data_sources_id_fk",
+          "tableFrom": "funnel_snapshots",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "integrations": {
+      "name": "integrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'kommo'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_domain": {
+          "name": "account_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_pipeline_id": {
+          "name": "selected_pipeline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_pipeline_name": {
+          "name": "selected_pipeline_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "integrations_tenant_id_tenants_id_fk": {
+          "name": "integrations_tenant_id_tenants_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lead_extras": {
+      "name": "lead_extras",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'normal'"
+        },
+        "custom_fields": {
+          "name": "custom_fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "lead_extras_lead_id_unique": {
+          "name": "lead_extras_lead_id_unique",
+          "columns": [
+            "lead_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "lead_extras_lead_id_leads_id_fk": {
+          "name": "lead_extras_lead_id_leads_id_fk",
+          "tableFrom": "lead_extras",
+          "tableTo": "leads",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lead_extras_tenant_id_tenants_id_fk": {
+          "name": "lead_extras_tenant_id_tenants_id_fk",
+          "tableFrom": "lead_extras",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "leads": {
+      "name": "leads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kommo_id": {
+          "name": "kommo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responsible_name": {
+          "name": "responsible_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'—'"
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "loss_reason": {
+          "name": "loss_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leads_tenant_id_tenants_id_fk": {
+          "name": "leads_tenant_id_tenants_id_fk",
+          "tableFrom": "leads",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "leads_pipeline_id_pipelines_id_fk": {
+          "name": "leads_pipeline_id_pipelines_id_fk",
+          "tableFrom": "leads",
+          "tableTo": "pipelines",
+          "columnsFrom": [
+            "pipeline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "leads_stage_id_stages_id_fk": {
+          "name": "leads_stage_id_stages_id_fk",
+          "tableFrom": "leads",
+          "tableTo": "stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metrics": {
+      "name": "metrics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric_key": {
+          "name": "metric_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "extra": {
+          "name": "extra",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "metrics_lookup_idx": {
+          "name": "metrics_lookup_idx",
+          "columns": [
+            "tenant_id",
+            "source",
+            "metric_key",
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "metrics_tenant_id_tenants_id_fk": {
+          "name": "metrics_tenant_id_tenants_id_fk",
+          "tableFrom": "metrics",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "metrics_data_source_id_data_sources_id_fk": {
+          "name": "metrics_data_source_id_data_sources_id_fk",
+          "tableFrom": "metrics",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "password_reset_tokens_token_unique": {
+          "name": "password_reset_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pipelines": {
+      "name": "pipelines",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kommo_id": {
+          "name": "kommo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pipelines_tenant_id_tenants_id_fk": {
+          "name": "pipelines_tenant_id_tenants_id_fk",
+          "tableFrom": "pipelines",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plan_modules": {
+      "name": "plan_modules",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "module_key": {
+          "name": "module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_modules_plan_id_plans_id_fk": {
+          "name": "plan_modules_plan_id_plans_id_fk",
+          "tableFrom": "plan_modules",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "plan_modules_plan_id_module_key_pk": {
+          "columns": [
+            "plan_id",
+            "module_key"
+          ],
+          "name": "plan_modules_plan_id_module_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plans": {
+      "name": "plans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_teams": {
+      "name": "sales_teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#FFB400'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sales_teams_tenant_id_tenants_id_fk": {
+          "name": "sales_teams_tenant_id_tenants_id_fk",
+          "tableFrom": "sales_teams",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stages": {
+      "name": "stages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kommo_id": {
+          "name": "kommo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#AAAAAA'"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stages_pipeline_id_pipelines_id_fk": {
+          "name": "stages_pipeline_id_pipelines_id_fk",
+          "tableFrom": "stages",
+          "tableTo": "pipelines",
+          "columnsFrom": [
+            "pipeline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_members": {
+      "name": "team_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responsible_name": {
+          "name": "responsible_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_team_id_sales_teams_id_fk": {
+          "name": "team_members_team_id_sales_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "sales_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_tenant_id_tenants_id_fk": {
+          "name": "team_members_tenant_id_tenants_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_modules": {
+      "name": "tenant_modules",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "module_key": {
+          "name": "module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_modules_tenant_id_tenants_id_fk": {
+          "name": "tenant_modules_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_modules",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tenant_modules_tenant_id_module_key_pk": {
+          "columns": [
+            "tenant_id",
+            "module_key"
+          ],
+          "name": "tenant_modules_tenant_id_module_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenants": {
+      "name": "tenants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#FFB400'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "avatar_color": {
+          "name": "avatar_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#FFB400'"
+        },
+        "avatar_bg": {
+          "name": "avatar_bg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#121316'"
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "users_tenant_id_tenants_id_fk": {
+          "name": "users_tenant_id_tenants_id_fk",
+          "tableFrom": "users",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,20 @@
       "when": 1780799720873,
       "tag": "0004_complete_bastion",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1782096081228,
+      "tag": "0005_nasty_proudstar",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1782100016821,
+      "tag": "0006_spooky_invaders",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -236,10 +236,12 @@ export const dataSources = sqliteTable('data_sources', {
   lastSyncAt: integer('last_sync_at', { mode: 'timestamp' }),
   lastSyncStatus: text('last_sync_status'),               // 'success' | 'error' | 'running'
   lastSyncError: text('last_sync_error'),
+  webhookToken: text('webhook_token'),                      // nullable; set only for webhook-based providers
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
   updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
 }, (t) => ({
   tenantProviderIdx: index('data_sources_tenant_provider_idx').on(t.tenantId, t.providerKey),
+  webhookTokenUnq: unique('data_sources_webhook_token_idx').on(t.webhookToken),
 }))
 
 // Generic numeric time-series (ad insights, KPIs, funnel counts over time, ...).
@@ -307,6 +309,27 @@ export const funnelSnapshots = sqliteTable('funnel_snapshots', {
   syncedAt: integer('synced_at', { mode: 'timestamp' }),
 }, (t) => ({
   periodIdx: index('funnel_snapshots_period_idx').on(t.tenantId, t.source, t.period),
+}))
+
+// Contact / conversation participant (WhatsApp end-user, CRM contact, etc.).
+// id is deterministic (tenant:source:externalId) so webhook upserts are idempotent.
+export const contacts = sqliteTable('contacts', {
+  id: text('id').primaryKey(),
+  tenantId: text('tenant_id').notNull().references(() => tenants.id),
+  dataSourceId: text('data_source_id').references(() => dataSources.id),
+  source: text('source').notNull(),
+  externalId: text('external_id').notNull(),  // stable id at origin (E.164 phone or provider contact id)
+  name: text('name'),
+  phone: text('phone'),
+  email: text('email'),
+  tags: text('tags').notNull().default('[]'),            // JSON string[]
+  lastInteractionAt: integer('last_interaction_at', { mode: 'timestamp' }),
+  metadata: text('metadata').notNull().default('{}'),
+  extra: text('extra').notNull().default('{}'),
+  createdAt: integer('created_at', { mode: 'timestamp' }),
+  syncedAt: integer('synced_at', { mode: 'timestamp' }),
+}, (t) => ({
+  lookupIdx: index('contacts_lookup_idx').on(t.tenantId, t.source, t.lastInteractionAt),
 }))
 
 // Campaign / parameters config per tenant (the "Parâmetros" tab). Passive-persisted,

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,0 +1,12 @@
+export function timeAgo(ms: number | null): string {
+  if (!ms) return '—'
+  const diff = Date.now() - ms
+  const secs = Math.floor(diff / 1000)
+  if (secs < 60) return 'agora'
+  const mins = Math.floor(secs / 60)
+  if (mins < 60) return `${mins}min`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h`
+  const days = Math.floor(hrs / 24)
+  return `${days}d`
+}

--- a/lib/modules.ts
+++ b/lib/modules.ts
@@ -20,11 +20,20 @@ export const MODULES: ModuleDef[] = [
   { key: 'integration.meta-ads',   label: 'Meta Ads',          type: 'integration',   path: '/settings/integrations/meta-ads' },
   { key: 'integration.tiktok-ads', label: 'TikTok Ads',        type: 'integration',   path: '/settings/integrations/tiktok-ads' },
   { key: 'integration.ai',         label: 'IA / Assistente',   type: 'integration',   path: '/settings/integrations/ai' },
+  { key: 'integration.ycloud-whatsapp', label: 'YCloud (WhatsApp)', type: 'integration', path: '/settings/integrations/ycloud' },
 ]
 
 export const ALL_MODULE_KEYS: string[] = MODULES.map(m => m.key)
 
+// Extra path → module-key mappings for sub-routes that don't have their own
+// MODULES entry (avoids duplicate keys in ALL_MODULE_KEYS / backfill scripts).
+const PATH_MODULE_OVERRIDES: Record<string, string> = {
+  '/sdr-ia/contatos':  'integration.ycloud-whatsapp',
+  '/sdr-ia/conversas': 'integration.ycloud-whatsapp',
+}
+
 export function moduleKeyForPath(pathname: string): string | null {
+  if (PATH_MODULE_OVERRIDES[pathname]) return PATH_MODULE_OVERRIDES[pathname]
   const sorted = [...MODULES].sort((a, b) => b.path.length - a.path.length)
   for (const m of sorted) {
     if (pathname === m.path || pathname.startsWith(m.path + '/')) return m.key
@@ -36,6 +45,16 @@ export const ADS_PROVIDER_MODULE: Record<string, string> = {
   google_ads: 'integration.google-ads',
   meta_ads:   'integration.meta-ads',
   tiktok_ads: 'integration.tiktok-ads',
+}
+
+/** Maps a data_source.providerKey to the tenant module key that gates it. */
+export const PROVIDER_MODULE: Record<string, string> = {
+  'supabase-n8n':    'integration.sdr-source',
+  'ycloud-whatsapp': 'integration.ycloud-whatsapp',
+}
+
+export function getModuleKeyForProvider(providerKey: string): string | null {
+  return PROVIDER_MODULE[providerKey] ?? null
 }
 
 export function firstAllowedPath(modules: string[]): string {

--- a/lib/providers/registry.ts
+++ b/lib/providers/registry.ts
@@ -27,3 +27,6 @@ export function listProviders(): DataSourceProvider<any, any>[] {
 
 import { supabaseN8nProvider } from './supabase-n8n'
 registerProvider(supabaseN8nProvider)
+
+import { yCloudProvider } from './ycloud'
+registerProvider(yCloudProvider)

--- a/lib/providers/types.ts
+++ b/lib/providers/types.ts
@@ -56,12 +56,27 @@ export interface CanonicalFunnelStage {
   extra?: Record<string, unknown>
 }
 
+/** A contact / conversation participant (e.g. a WhatsApp end-user). */
+export interface CanonicalContact {
+  /** Stable id at the source — e.g. E.164 phone or the provider's contact id. */
+  externalId: string
+  name?: string
+  phone?: string
+  email?: string
+  tags?: string[]
+  /** Epoch ms of the most recent message / interaction. */
+  lastInteractionAt?: number
+  metadata?: Record<string, unknown>
+  extra?: Record<string, unknown>
+}
+
 /** What `normalize` returns for one fetched page. Any subset may be present. */
 export interface CanonicalBatch {
   metrics?: CanonicalMetric[]
   events?: CanonicalEvent[]
   conversations?: CanonicalConversation[]
   funnel?: CanonicalFunnelStage[]
+  contacts?: CanonicalContact[]
 }
 
 // ─── Sync plumbing ───────────────────────────────────────────────────────────────

--- a/lib/providers/ycloud.ts
+++ b/lib/providers/ycloud.ts
@@ -1,0 +1,533 @@
+import type {
+  DataSourceProvider,
+  FetchPage,
+  SyncContext,
+  CanonicalBatch,
+  CanonicalContact,
+  CanonicalConversation,
+  CanonicalEvent,
+} from './types'
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+export interface YCloudConfig {
+  apiKey: string
+  /** HMAC-SHA256 secret for verifying the YCloud-Signature header on webhooks. */
+  webhookSecret: string
+  /** E.164 business phone used as the sender for outbound WhatsApp messages. */
+  fromPhone: string
+}
+
+// ─── REST: Contact shapes (YCloud API v2 /contact/contacts) ──────────────────
+//
+// Source: https://docs.ycloud.com/reference/contact-list.md
+//
+// Pagination:  page (1-based, 1-100), limit (1-100), includeTotal
+// Response:    { items, total?, offset?, length? }
+// Contact:     id, phoneNumber (E.164), nickname (display name — no firstName/lastName),
+//              email, countryCode, countryName, tags[], lastSeen (RFC 3339),
+//              lastMessageToPhoneNumber, createTime, customAttributes[], ownerEmail, sourceType
+
+interface YCloudContactRaw {
+  id: string
+  phoneNumber?: string
+  nickname?: string
+  email?: string
+  countryCode?: string
+  countryName?: string
+  tags?: string[]
+  /** RFC 3339 — "time at which the contact last sent a message". */
+  lastSeen?: string
+  lastMessageToPhoneNumber?: string
+  createTime?: string
+  customAttributes?: Array<{ name: string; value: string }>
+  ownerEmail?: string
+  sourceType?: string
+  sourceId?: string
+  sourceUrl?: string
+}
+
+interface YCloudContactPage {
+  items: YCloudContactRaw[]
+  total?: number
+  offset?: number
+  length?: number
+}
+
+// ─── Webhook payload shapes (YCloud API v2) ──────────────────────────────────
+//
+// Sources:
+//   https://docs.ycloud.com/reference/whatsapp-inbound-message-webhook-examples.md
+//   https://docs.ycloud.com/reference/whatsapp-message-updated-webhook-examples.md
+
+interface YCloudEnvelope {
+  id: string
+  type: string
+  apiVersion?: string
+  createTime?: string
+}
+
+interface YCloudInboundMsg extends YCloudEnvelope {
+  type: 'whatsapp.inbound_message.received'
+  whatsappInboundMessage: {
+    id: string               // YCloud message id (deterministic sourceId)
+    wamid?: string           // WhatsApp platform message id
+    wabaId?: string
+    from: string             // customer phone in E.164 — used as sessionId AND externalId
+    fromUserId?: string
+    fromParentUserId?: string
+    customerProfile?: { name?: string; username?: string }
+    to: string               // business phone in E.164
+    sendTime?: string        // ISO-8601; use as occurredAt
+    type?: string            // 'text' | 'image' | 'audio' | ...
+    text?: { body: string }
+    context?: { from?: string; id?: string }
+  }
+}
+
+interface YCloudMessageUpdated extends YCloudEnvelope {
+  type: 'whatsapp.message.updated'
+  whatsappMessage: {
+    id: string
+    wamid?: string
+    recipientUserId?: string
+    parentRecipientUserId?: string
+    customerProfile?: { name?: string; username?: string }
+    status?: 'sent' | 'delivered' | 'read' | 'failed'
+    bizType?: string
+    type?: string
+    text?: { body: string }
+    externalId?: string
+    createTime?: string
+    sendTime?: string
+    deliverTime?: string
+    readTime?: string
+    totalPrice?: number
+    currency?: string
+    errorCode?: string
+    errorMessage?: string
+  }
+}
+
+// ─── Provider ─────────────────────────────────────────────────────────────────
+
+const YCLOUD_API_BASE = 'https://api.ycloud.com/v2'
+const CONTACT_PAGE_LIMIT = 100
+// YCloud page parameter is capped at 100 (range 1-100), so max 10 000 contacts per full sync.
+const MAX_CONTACT_PAGE = 100
+
+export const yCloudProvider: DataSourceProvider<YCloudConfig, YCloudContactRaw[]> = {
+  key: 'ycloud-whatsapp',
+  label: 'YCloud (WhatsApp)',
+
+  parseConfig(raw: unknown): YCloudConfig {
+    if (!raw || typeof raw !== 'object') {
+      throw new Error('YCloud: config deve ser um objeto')
+    }
+    const r = raw as Record<string, unknown>
+    if (!r.apiKey || typeof r.apiKey !== 'string' || r.apiKey.trim() === '') {
+      throw new Error('YCloud: apiKey é obrigatório e não pode ser vazio')
+    }
+    if (!r.webhookSecret || typeof r.webhookSecret !== 'string' || r.webhookSecret.trim() === '') {
+      throw new Error('YCloud: webhookSecret é obrigatório e não pode ser vazio')
+    }
+    const fromPhone = typeof r.fromPhone === 'string' ? r.fromPhone.trim() : ''
+    if (!fromPhone) {
+      throw new Error('YCloud: fromPhone (número remetente) é obrigatório')
+    }
+    // E.164: leading '+', first digit 1-9, 6-14 more digits → total 8-16 chars
+    if (!/^\+[1-9]\d{6,14}$/.test(fromPhone)) {
+      throw new Error('YCloud: fromPhone deve estar no formato E.164 (ex: +5511999999999)')
+    }
+    return { apiKey: r.apiKey.trim(), webhookSecret: r.webhookSecret.trim(), fromPhone }
+  },
+
+  // Validates the API key with the cheapest available read-only endpoint.
+  async testConnection(cfg: YCloudConfig): Promise<{ ok: boolean; message?: string }> {
+    try {
+      const res = await fetch(`${YCLOUD_API_BASE}/balance`, {
+        method: 'GET',
+        headers: { 'X-API-Key': cfg.apiKey },
+        signal: AbortSignal.timeout(8_000),
+      })
+      if (res.ok) return { ok: true }
+      const body = await res.text().catch(() => '')
+      return { ok: false, message: `HTTP ${res.status}: ${body.slice(0, 200)}` }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err)
+      return { ok: false, message: msg }
+    }
+  },
+
+  // Fetches a single page of contacts from the YCloud REST API.
+  //
+  // Conversations and status events do NOT come from here — they arrive exclusively
+  // via webhook (see app/api/webhooks/ycloud/[token]/route.ts). This fetch only
+  // populates the contacts table as a backfill / periodic refresh.
+  async fetch(cfg: YCloudConfig, ctx: SyncContext): Promise<FetchPage<YCloudContactRaw[]>> {
+    const cursor = ctx.cursor as { contactsPage?: number } | null
+    const page = cursor?.contactsPage ?? 1
+
+    const url = new URL(`${YCLOUD_API_BASE}/contact/contacts`)
+    url.searchParams.set('page', String(page))
+    url.searchParams.set('limit', String(CONTACT_PAGE_LIMIT))
+    url.searchParams.set('includeTotal', 'true')
+
+    let res: Response
+    try {
+      res = await fetch(url.toString(), {
+        method: 'GET',
+        headers: { 'X-API-Key': cfg.apiKey },
+        signal: AbortSignal.timeout(15_000),
+      })
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err)
+      throw new Error(`YCloud contacts: network/timeout error on page ${page}: ${msg}`)
+    }
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      throw new Error(`YCloud contacts: API error ${res.status} on page ${page}: ${body.slice(0, 200)}`)
+    }
+
+    const data = await res.json() as YCloudContactPage
+    const items = data.items ?? []
+
+    // done when:
+    //  • fewer items than requested (last page), OR
+    //  • total is known and we've covered it, OR
+    //  • API page cap reached (page 100 is the maximum, ≈10k contacts)
+    const coveredAll = data.total != null && page * CONTACT_PAGE_LIMIT >= data.total
+    const hitCap     = page >= MAX_CONTACT_PAGE
+
+    if (hitCap && !coveredAll) {
+      const synced = page * CONTACT_PAGE_LIMIT
+      const total  = data.total != null ? data.total : 'desconhecido'
+      console.warn(
+        `[ycloud contacts] cap de 100 páginas atingido; ${synced} de ${total} contatos sincronizados`
+      )
+    }
+
+    const done = items.length < CONTACT_PAGE_LIMIT || coveredAll || hitCap
+
+    return {
+      raw: items,
+      nextCursor: { contactsPage: page + 1 },
+      done,
+    }
+  },
+
+  // Maps one page of YCloud Contact records to CanonicalContact.
+  //
+  // externalId = phoneNumber (E.164) — identical to msg.from used in webhooks,
+  // guaranteeing that REST backfill and webhook upserts hit the same row (no duplicates).
+  // Falls back to the YCloud contact id when phoneNumber is absent (edge case).
+  //
+  // lastInteractionAt = parseMs(lastSeen). The upsertBatch MAX logic ensures this never
+  // regresses a more recent timestamp written by an earlier webhook event.
+  normalize(raw: YCloudContactRaw[], _ctx: SyncContext): CanonicalBatch {
+    const contacts: CanonicalContact[] = raw.map(c => {
+      const externalId = c.phoneNumber ?? c.id
+
+      return {
+        externalId,
+        name:  c.nickname ?? undefined,
+        phone: c.phoneNumber ?? undefined,
+        email: c.email ?? undefined,
+        tags:  c.tags ?? [],
+        // lastSeen = "time contact last sent a message" — best available proxy for lastInteractionAt
+        lastInteractionAt: parseMs(c.lastSeen),
+        metadata: {
+          yCloudId:                c.id,
+          countryCode:             c.countryCode,
+          countryName:             c.countryName,
+          lastMessageToPhoneNumber: c.lastMessageToPhoneNumber,
+          sourceType:              c.sourceType,
+        },
+        extra: {
+          customAttributes: c.customAttributes ?? [],
+          ownerEmail:       c.ownerEmail,
+        },
+      }
+    })
+
+    return { contacts }
+  },
+}
+
+// ─── Webhook normalizer ───────────────────────────────────────────────────────
+//
+// Pure function (no I/O) called by the webhook route to convert a raw YCloud
+// event into canonical platform records for upsert into Turso.
+
+/** Parses an ISO-8601 string to epoch ms; returns undefined on missing/invalid input. */
+function parseMs(iso: string | undefined): number | undefined {
+  if (!iso) return undefined
+  const ms = Date.parse(iso)
+  return Number.isNaN(ms) ? undefined : ms
+}
+
+/**
+ * Maps a raw YCloud webhook event payload to a CanonicalBatch.
+ *
+ * Handled event types:
+ *   whatsapp.inbound_message.received → CanonicalConversation (role: 'human')
+ *                                     + CanonicalContact (externalId = msg.from = E.164 phone)
+ *   whatsapp.message.updated          → CanonicalEvent (eventType: whatsapp_status_*)
+ *
+ * The CanonicalContact emitted on each inbound message ensures the contacts table
+ * stays populated in real-time without requiring a REST backfill first.
+ * externalId = msg.from (E.164) matches phoneNumber from the REST endpoint — both
+ * refer to the same contact row (idempotent upsert, no duplicates).
+ *
+ * All other event types return an empty batch (never throws).
+ */
+export function normalizeWebhookEvent(
+  event: unknown,
+  _ctx: { tenantId: string },
+): CanonicalBatch {
+  if (!event || typeof event !== 'object') return {}
+
+  const env = event as YCloudEnvelope
+
+  switch (env.type) {
+    case 'whatsapp.inbound_message.received': {
+      const e = event as YCloudInboundMsg
+      const msg = e.whatsappInboundMessage
+      if (!msg?.id || !msg.from) return {}
+
+      // For non-text messages (image, audio, video, …) there is no text.body;
+      // use a bracketed type placeholder so content is never stored empty.
+      const content = msg.text?.body ?? (msg.type ? `[${msg.type}]` : '[unknown]')
+
+      const occurredAt = parseMs(msg.sendTime) ?? parseMs(env.createTime)
+
+      const conversation: CanonicalConversation = {
+        sourceId:  msg.id,
+        sessionId: msg.from,          // customer E.164 phone — stable session key
+        role:      'human',
+        content,
+        occurredAt,
+        metadata: {
+          wamid:        msg.wamid,
+          from:         msg.from,
+          to:           msg.to,
+          messageType:  msg.type,
+          customerName: msg.customerProfile?.name,
+          replyToWamid: msg.context?.id,
+        },
+      }
+
+      // Upsert a contact so the contacts table stays up-to-date with every inbound message.
+      // externalId = msg.from (E.164) = phoneNumber from REST — guaranteed same row, no duplicates.
+      // The upsertBatch MAX logic ensures occurredAt only advances, never regresses.
+      const contact: CanonicalContact = {
+        externalId: msg.from,
+        name:       msg.customerProfile?.name,
+        phone:      msg.from,
+        lastInteractionAt: occurredAt,
+        metadata: {
+          customerUsername: msg.customerProfile?.username,
+        },
+      }
+
+      return { conversations: [conversation], contacts: [contact] }
+    }
+
+    case 'whatsapp.message.updated': {
+      const e = event as YCloudMessageUpdated
+      const msg = e.whatsappMessage
+      if (!msg?.id || !msg.status) return {}
+
+      // Pick the timestamp that best reflects when this specific transition occurred,
+      // falling back through the chain to the envelope's createTime (always present).
+      const occurredAt =
+        (msg.status === 'read'      ? parseMs(msg.readTime)    : undefined) ??
+        (msg.status === 'delivered' ? parseMs(msg.deliverTime) : undefined) ??
+        parseMs(msg.sendTime) ??
+        parseMs(msg.createTime) ??
+        parseMs(env.createTime)
+
+      const ev: CanonicalEvent = {
+        sourceId:  `${msg.id}:${msg.status}`,   // deterministic — safe to upsert repeatedly
+        eventType: `whatsapp_status_${msg.status}`,
+        entityId:  msg.recipientUserId,
+        occurredAt: occurredAt ?? 0,
+        payload: {
+          messageId:    msg.id,
+          wamid:        msg.wamid,
+          status:       msg.status,
+          errorCode:    msg.errorCode,
+          errorMessage: msg.errorMessage,
+        },
+      }
+      return { events: [ev] }
+    }
+
+    default:
+      return {}
+  }
+}
+
+// ─── Messaging actions ────────────────────────────────────────────────────────
+//
+// Sending is an action, NOT part of the DataSourceProvider sync contract.
+// These functions are exported separately and called from action-layer API routes.
+
+export type SendWhatsappParams =
+  | { to: string; type: 'text'; body: string }
+  | {
+      to: string
+      type: 'template'
+      templateName: string
+      languageCode: string
+      /** Body components, e.g. [{ type:'body', parameters:[{ type:'text', text:'...' }] }].
+       *  Omit or pass [] if the template has no variables. */
+      components?: unknown[]
+    }
+
+export interface SendWhatsappResult {
+  /** YCloud message identifier — field name 'id' in the WhatsappMessage response object. */
+  id: string
+  status?: string
+}
+
+/**
+ * Sends a WhatsApp message (text or template) via the YCloud API.
+ *
+ * POST /v2/whatsapp/messages  ·  auth: X-API-Key
+ *
+ * Text body:
+ *   { from, to, type:'text', text:{ body, preview_url:false } }
+ *
+ * Template body:
+ *   { from, to, type:'template', template:{ name, language:{ code }, components? } }
+ *   components is omitted from the request when empty/undefined.
+ *
+ * Returns { id, status } from the YCloud WhatsappMessage response.
+ * Throws a descriptive Error on non-2xx or timeout (includes HTTP status + YCloud detail).
+ */
+export async function sendWhatsappMessage(
+  cfg: YCloudConfig,
+  params: SendWhatsappParams,
+): Promise<SendWhatsappResult> {
+  let requestBody: Record<string, unknown>
+
+  if (params.type === 'text') {
+    requestBody = {
+      from: cfg.fromPhone,
+      to:   params.to,
+      type: 'text',
+      text: { body: params.body, preview_url: false },
+    }
+  } else {
+    const template: Record<string, unknown> = {
+      name:     params.templateName,
+      language: { code: params.languageCode },
+    }
+    if (params.components && params.components.length > 0) {
+      template.components = params.components
+    }
+    requestBody = {
+      from:     cfg.fromPhone,
+      to:       params.to,
+      type:     'template',
+      template,
+    }
+  }
+
+  let res: Response
+  try {
+    res = await fetch(`${YCLOUD_API_BASE}/whatsapp/messages`, {
+      method:  'POST',
+      headers: {
+        'X-API-Key':    cfg.apiKey,
+        'Content-Type': 'application/json',
+      },
+      body:   JSON.stringify(requestBody),
+      signal: AbortSignal.timeout(15_000),
+    })
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`YCloud send: network/timeout error: ${msg}`)
+  }
+
+  if (!res.ok) {
+    let detail = ''
+    try {
+      const errBody = await res.json() as Record<string, unknown>
+      detail = String(errBody.message ?? errBody.error ?? JSON.stringify(errBody))
+    } catch {
+      detail = await res.text().catch(() => '')
+    }
+    throw new Error(`YCloud send: HTTP ${res.status} – ${detail.slice(0, 300)}`)
+  }
+
+  const data = await res.json() as { id: string; status?: string }
+  return { id: data.id, status: data.status }
+}
+
+// ─── Template listing ─────────────────────────────────────────────────────────
+
+export interface WhatsappTemplate {
+  name:        string
+  language:    string
+  category?:   string
+  status:      string
+  components?: unknown[]
+}
+
+interface YCloudTemplatesPage {
+  items: WhatsappTemplate[]
+  total?: number
+}
+
+/**
+ * Returns all WhatsApp message templates for this account.
+ *
+ * GET /v2/whatsapp/templates?limit=100&page=N  ·  auth: X-API-Key
+ * Paginates automatically until items.length < limit (last page).
+ *
+ * status field values include 'approved', 'rejected', 'pending', etc.
+ * The caller (or UI) should filter by status === 'approved' as needed.
+ * Throws on non-2xx or timeout.
+ */
+export async function listWhatsappTemplates(
+  cfg: YCloudConfig,
+): Promise<WhatsappTemplate[]> {
+  const LIMIT = 100
+  const all: WhatsappTemplate[] = []
+  let page = 1
+
+  for (;;) {
+    const url = new URL(`${YCLOUD_API_BASE}/whatsapp/templates`)
+    url.searchParams.set('limit', String(LIMIT))
+    url.searchParams.set('page',  String(page))
+
+    let res: Response
+    try {
+      res = await fetch(url.toString(), {
+        method:  'GET',
+        headers: { 'X-API-Key': cfg.apiKey },
+        signal:  AbortSignal.timeout(15_000),
+      })
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err)
+      throw new Error(`YCloud templates: network/timeout error on page ${page}: ${msg}`)
+    }
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      throw new Error(`YCloud templates: HTTP ${res.status} on page ${page}: ${body.slice(0, 200)}`)
+    }
+
+    const data = await res.json() as YCloudTemplatesPage
+    const items = data.items ?? []
+    all.push(...items)
+
+    if (items.length < LIMIT) break
+    page++
+  }
+
+  return all
+}

--- a/lib/sync/runner.ts
+++ b/lib/sync/runner.ts
@@ -7,6 +7,7 @@ import {
   events,
   conversations,
   funnelSnapshots,
+  contacts,
 } from '@/lib/db/schema'
 import { decrypt } from '@/lib/crypto'
 import { getProvider } from '@/lib/providers/registry'
@@ -19,6 +20,7 @@ interface UpsertCounts {
   events: number
   conversations: number
   funnel: number
+  contacts: number
 }
 
 const CHUNK_SIZE = 150
@@ -34,14 +36,14 @@ function hashDims(dims: Record<string, unknown> | undefined): string {
   return createHash('sha256').update(JSON.stringify(dims)).digest('hex').slice(0, 16)
 }
 
-async function upsertBatch(
+export async function upsertBatch(
   batch: CanonicalBatch,
   tenantId: string,
   dataSourceId: string,
   source: string
 ): Promise<UpsertCounts> {
   const now = new Date()
-  const counts: UpsertCounts = { metrics: 0, events: 0, conversations: 0, funnel: 0 }
+  const counts: UpsertCounts = { metrics: 0, events: 0, conversations: 0, funnel: 0, contacts: 0 }
 
   if (batch.metrics?.length) {
     const rows = batch.metrics.map(m => ({
@@ -158,6 +160,48 @@ async function upsertBatch(
     counts.funnel = rows.length
   }
 
+  if (batch.contacts?.length) {
+    const rows = batch.contacts.map(c => ({
+      id: `${tenantId}:${source}:${c.externalId}`,
+      tenantId,
+      dataSourceId,
+      source,
+      externalId:         c.externalId,
+      name:               c.name ?? null,
+      phone:              c.phone ?? null,
+      email:              c.email ?? null,
+      tags:               JSON.stringify(c.tags ?? []),
+      lastInteractionAt:  c.lastInteractionAt != null ? new Date(c.lastInteractionAt) : null,
+      metadata:           JSON.stringify(c.metadata ?? {}),
+      extra:              JSON.stringify(c.extra ?? {}),
+      createdAt:          now,
+      syncedAt:           now,
+    }))
+    for (const chk of chunk(rows, CHUNK_SIZE)) {
+      await db.insert(contacts).values(chk).onConflictDoUpdate({
+        target: contacts.id,
+        set: {
+          // name/phone/email: preserve existing non-null/non-empty value when new value is absent.
+          // NULLIF(x, '') converts '' to NULL so COALESCE falls back to the stored value.
+          name:              sql`COALESCE(NULLIF(excluded.name, ''), contacts.name)`,
+          phone:             sql`COALESCE(NULLIF(excluded.phone, ''), contacts.phone)`,
+          email:             sql`COALESCE(NULLIF(excluded.email, ''), contacts.email)`,
+          // tags/metadata/extra: always take the latest payload.
+          tags:              sql`excluded.tags`,
+          metadata:          sql`excluded.metadata`,
+          extra:             sql`excluded.extra`,
+          // lastInteractionAt: keep the highest timestamp seen so far.
+          // COALESCE(…, 0) lets MAX work with NULLs; NULLIF(…, 0) converts the
+          // "both were NULL → 0" edge case back to NULL instead of storing epoch 0.
+          lastInteractionAt: sql`NULLIF(MAX(COALESCE(excluded.last_interaction_at, 0), COALESCE(contacts.last_interaction_at, 0)), 0)`,
+          // createdAt: intentionally omitted — preserved from the original INSERT.
+          syncedAt:          sql`excluded.synced_at`,
+        },
+      })
+    }
+    counts.contacts = rows.length
+  }
+
   return counts
 }
 
@@ -166,7 +210,7 @@ export async function runSync(dataSource: DataSource): Promise<{
   counts: UpsertCounts
   error?: string
 }> {
-  const counts: UpsertCounts = { metrics: 0, events: 0, conversations: 0, funnel: 0 }
+  const counts: UpsertCounts = { metrics: 0, events: 0, conversations: 0, funnel: 0, contacts: 0 }
 
   const provider = getProvider(dataSource.providerKey)
   if (!provider) {
@@ -214,6 +258,7 @@ export async function runSync(dataSource: DataSource): Promise<{
       counts.events += pageCounts.events
       counts.conversations += pageCounts.conversations
       counts.funnel += pageCounts.funnel
+      counts.contacts += pageCounts.contacts
 
       await db.update(dataSources)
         .set({ syncCursor: JSON.stringify(fetchPage.nextCursor) })

--- a/middleware.ts
+++ b/middleware.ts
@@ -14,7 +14,8 @@ export default auth((req) => {
     pathname.startsWith('/login') ||
     pathname.startsWith('/forgot-password') ||
     pathname.startsWith('/reset-password') ||
-    pathname.startsWith('/api/auth')
+    pathname.startsWith('/api/auth') ||
+    pathname.startsWith('/api/webhooks/')
 
   // 1. Master on /login → /master
   if (isLoggedIn && isMaster && pathname === '/login') {


### PR DESCRIPTION
Integração ponta-a-ponta do provider ycloud-whatsapp, gateada pelo módulo integration.ycloud-whatsapp:

- Conexão: API key + webhook secret + número remetente (config criptografada AES-256-GCM); página de settings e rotas /api/ycloud/source (+ /test).
- Webhook por tenant (/api/webhooks/ycloud/[token]) autenticado por HMAC-SHA256, idempotente; grava conversas inbound e eventos de status. (A API v2 do YCloud não lista mensagens — webhook é o único caminho.)
- Contatos: tabela canônica contacts populada via REST (/contact/contacts) e webhook; página /sdr-ia/contatos e API /api/contacts.
- Métricas WhatsApp on-read agregando events (totais exatos via SQL); merge das sessões recentes e novos cards/gráficos no dashboard SDR.
- Envio bidirecional: /api/ycloud/messages (texto/template) com guarda da janela de 24h e registro outbound role='ai'; view de conversa /sdr-ia/conversas com composer texto/template; /api/ycloud/templates.
- Cron de sync generalizado por providerKey→módulo (sem afetar supabase-n8n nem os ads, que usam outro caminho); migrations 0005/0006.