### PR TITLE
fix: teste de conexão YCloud não deve exigir fromPhone

### DIFF
--- a/app/api/ycloud/source/test/route.ts
+++ b/app/api/ycloud/source/test/route.ts
@@ -27,17 +27,11 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ valid: false, error: 'Provider não encontrado' })
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let cfg: any
+  // O teste de conexão valida apenas a API key (chama o YCloud /balance).
+  // fromPhone NÃO é necessário aqui — só é exigido ao salvar (parseConfig),
+  // então não passamos pelo parseConfig estrito para não bloquear o teste.
   try {
-    cfg = provider.parseConfig({ apiKey, webhookSecret })
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return NextResponse.json({ valid: false, error: msg })
-  }
-
-  try {
-    const result = await provider.testConnection(cfg)
+    const result = await provider.testConnection({ apiKey, webhookSecret, fromPhone: '' })
     return NextResponse.json({ valid: result.ok, error: result.message })
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
A rota /api/ycloud/source/test chamava parseConfig (que passou a exigir
fromPhone na Fase 3), fazendo o botão "Testar conexão" falhar sempre com
"fromPhone é obrigatório" — mesmo com o número preenchido — já que o
frontend não envia fromPhone no teste. O teste só valida a API key via
/balance, então agora chama testConnection diretamente, sem o parseConfig
estrito. fromPhone continua obrigatório apenas no salvar.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
