### PR TITLE
feat: disparar campanha pelo painel + campos de campanha (remetente/toques/intervalo)

### DIFF
--- a/app/(app)/sdr-ia/parametros/page.tsx
+++ b/app/(app)/sdr-ia/parametros/page.tsx
@@ -10,14 +10,18 @@ type Status = 'draft' | 'active' | 'paused'
 type N8nDelivery = { ok: boolean; status?: number; error?: string } | null
 
 interface Settings {
-  tom:            Tom
-  objetivo:       string
-  delay:          number
-  limiteDiario:   number
-  horario:        { inicio: string; fim: string }
-  diasAtivos:     number[]
-  templates:      string[]
-  n8nWebhookUrl?: string  // returned by GET; extracted to separate state on load
+  tom:              Tom
+  objetivo:         string
+  delay:            number   // legado — em horas; não usado pela campanha n8n
+  limiteDiario:     number
+  horario:          { inicio: string; fim: string }
+  diasAtivos:       number[]
+  templates:        string[]
+  remetente:        string   // E.164, ex: +5511999990000
+  numToques:        number   // 1–20
+  intervaloDias:    number   // 1–30, intervalo entre toques
+  n8nWebhookUrl?:   string  // returned by GET; extracted to separate state on load
+  n8nDispatchUrl?:  string  // returned by GET; extracted to separate state on load
 }
 
 interface ApiData {
@@ -30,14 +34,20 @@ interface ApiData {
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const DEFAULTS: Settings = {
-  tom:          'consultivo',
-  objetivo:     '',
-  delay:        24,
-  limiteDiario: 100,
-  horario:      { inicio: '08:00', fim: '18:00' },
-  diasAtivos:   [1, 2, 3, 4, 5],
-  templates:    [''],
+  tom:           'consultivo',
+  objetivo:      '',
+  delay:         24,
+  limiteDiario:  100,
+  horario:       { inicio: '08:00', fim: '18:00' },
+  diasAtivos:    [1, 2, 3, 4, 5],
+  templates:     [''],
+  remetente:     '',
+  numToques:     10,
+  intervaloDias: 3,
 }
+
+const E164_RE = /^\+[1-9]\d{6,14}$/
+function isValidE164(v: string) { return v === '' || E164_RE.test(v) }
 
 const DIAS = [
   { num: 1, label: 'Seg' }, { num: 2, label: 'Ter' },
@@ -94,32 +104,43 @@ function TimeInput({ value, onChange }: { value: string; onChange: (v: string) =
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function ParametrosPage() {
-  const [settings,         setSettings]         = useState<Settings>(DEFAULTS)
-  const [status,           setStatus]           = useState<Status>('draft')
-  const [n8nWebhookUrl,    setN8nWebhookUrl]    = useState('')
-  const [n8nWebhookSecret, setN8nWebhookSecret] = useState('')
-  const [showSecret,       setShowSecret]       = useState(false)
-  const [loading,          setLoading]          = useState(true)
-  const [saving,           setSaving]           = useState(false)
-  const [saved,            setSaved]            = useState(false)
-  const [saveError,        setSaveError]        = useState<string | null>(null)
-  const [n8nDelivery,      setN8nDelivery]      = useState<N8nDelivery | undefined>(undefined)
+  const [settings,           setSettings]           = useState<Settings>(DEFAULTS)
+  const [status,             setStatus]             = useState<Status>('draft')
+  const [n8nWebhookUrl,      setN8nWebhookUrl]      = useState('')
+  const [n8nWebhookSecret,   setN8nWebhookSecret]   = useState('')
+  const [showSecret,         setShowSecret]         = useState(false)
+  const [n8nDispatchUrl,     setN8nDispatchUrl]     = useState('')
+  const [n8nDispatchSecret,  setN8nDispatchSecret]  = useState('')
+  const [showDispatchSecret, setShowDispatchSecret] = useState(false)
+  const [dispatching,        setDispatching]        = useState(false)
+  const [dispatchResult,     setDispatchResult]     = useState<{ ok: boolean; status?: number; error?: string } | undefined>(undefined)
+  const [remetenteError,     setRemetenteError]     = useState<string | null>(null)
+  const [loading,            setLoading]            = useState(true)
+  const [saving,             setSaving]             = useState(false)
+  const [saved,              setSaved]              = useState(false)
+  const [saveError,          setSaveError]          = useState<string | null>(null)
+  const [n8nDelivery,        setN8nDelivery]        = useState<N8nDelivery | undefined>(undefined)
 
   useEffect(() => {
     fetch('/api/sdr/settings')
       .then(r => r.ok ? r.json() : Promise.reject(r.status))
       .then((d: ApiData) => {
-        const { n8nWebhookUrl: webhookUrl, ...coreSettings } = d.settings
+        const { n8nWebhookUrl: webhookUrl, n8nDispatchUrl: dispatchUrl, ...coreSettings } = d.settings
         setSettings({ ...DEFAULTS, ...coreSettings })
         setStatus(d.status)
         setN8nWebhookUrl(webhookUrl ?? '')
-        // n8nWebhookSecret is never returned by GET — field stays empty intentionally
+        setN8nDispatchUrl(dispatchUrl ?? '')
+        // secrets are never returned by GET — fields stay empty intentionally
       })
       .catch(() => {})
       .finally(() => setLoading(false))
   }, [])
 
   async function save() {
+    if (!isValidE164(settings.remetente)) {
+      setSaveError('Remetente inválido — use formato E.164 (ex: +5511999990000)')
+      return
+    }
     setSaving(true)
     setSaved(false)
     setSaveError(null)
@@ -128,8 +149,10 @@ export default function ParametrosPage() {
       const settingsPayload = {
         ...settings,
         n8nWebhookUrl,
-        // omit secret when blank — server preserves the previously stored value
-        ...(n8nWebhookSecret ? { n8nWebhookSecret } : {}),
+        // omit secrets when blank — server preserves the previously stored values
+        ...(n8nWebhookSecret  ? { n8nWebhookSecret }  : {}),
+        n8nDispatchUrl,
+        ...(n8nDispatchSecret ? { n8nDispatchSecret } : {}),
       }
       const res = await fetch('/api/sdr/settings', {
         method: 'PUT',
@@ -145,6 +168,20 @@ export default function ParametrosPage() {
       setSaveError((e as Error).message)
     } finally {
       setSaving(false)
+    }
+  }
+
+  async function dispatch() {
+    setDispatching(true)
+    setDispatchResult(undefined)
+    try {
+      const res = await fetch('/api/sdr/dispatch', { method: 'POST' })
+      const data = await res.json() as { ok: boolean; status?: number; error?: string }
+      setDispatchResult(data)
+    } catch (e) {
+      setDispatchResult({ ok: false, error: (e as Error).message })
+    } finally {
+      setDispatching(false)
     }
   }
 
@@ -264,12 +301,101 @@ export default function ParametrosPage() {
         />
       </SectionCard>
 
+      {/* ── Sequência de disparo ────────────────────────────────── */}
+      <SectionCard title="Sequência de disparo">
+        <div style={{ marginBottom: 20 }}>
+          <FieldLabel>Número remetente (WhatsApp Business)</FieldLabel>
+          <input
+            type="tel"
+            value={settings.remetente}
+            onChange={e => {
+              upd('remetente', e.target.value)
+              if (remetenteError) setRemetenteError(null)
+            }}
+            onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+            onBlur={e => {
+              const valid = isValidE164(e.target.value)
+              e.currentTarget.style.borderColor = valid ? 'var(--gray3)' : 'var(--red)'
+              setRemetenteError(valid ? null : 'Formato inválido — use E.164: +5511999990000')
+            }}
+            placeholder="+5511999990000"
+            style={{
+              width: '100%', fontFamily: 'inherit', fontSize: 13,
+              border: `1px solid ${remetenteError ? 'var(--red)' : 'var(--gray3)'}`,
+              borderRadius: 10, padding: '10px 14px',
+              background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+              boxSizing: 'border-box', transition: 'border-color .15s',
+            }}
+          />
+          {remetenteError && (
+            <div style={{ fontSize: 11, color: 'var(--red)', fontWeight: 600, marginTop: 5 }}>
+              {remetenteError}
+            </div>
+          )}
+          <div style={{ fontSize: 11, color: 'var(--gray2)', fontWeight: 500, marginTop: 6, lineHeight: 1.5 }}>
+            Número WhatsApp Business usado nos disparos. Formato E.164 (ex: +5511999990000).
+          </div>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 24 }}>
+          <div>
+            <FieldLabel>
+              Toques na sequência{' '}
+              <span style={{ color: 'var(--primary-text)', fontWeight: 900 }}>{settings.numToques}</span>
+            </FieldLabel>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <input
+                type="number"
+                min={1} max={20}
+                value={settings.numToques}
+                onChange={e => upd('numToques', Math.max(1, Math.min(20, Number(e.target.value))))}
+                style={{
+                  width: 80, fontFamily: 'inherit', fontSize: 16, fontWeight: 800,
+                  border: '1px solid var(--gray3)', borderRadius: 8, padding: '8px 12px',
+                  background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+                  textAlign: 'center', transition: 'border-color .15s',
+                }}
+                onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+                onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+              />
+              <span style={{ fontSize: 13, color: 'var(--gray2)', fontWeight: 500 }}>templates</span>
+            </div>
+            <div style={{ fontSize: 11, color: 'var(--gray2)', fontWeight: 500, marginTop: 6 }}>1–20. Define fase_final = &quot;Template {settings.numToques}&quot;.</div>
+          </div>
+
+          <div>
+            <FieldLabel>
+              Intervalo entre toques{' '}
+              <span style={{ color: 'var(--primary-text)', fontWeight: 900 }}>{settings.intervaloDias}</span>
+            </FieldLabel>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <input
+                type="number"
+                min={1} max={30}
+                value={settings.intervaloDias}
+                onChange={e => upd('intervaloDias', Math.max(1, Math.min(30, Number(e.target.value))))}
+                style={{
+                  width: 80, fontFamily: 'inherit', fontSize: 16, fontWeight: 800,
+                  border: '1px solid var(--gray3)', borderRadius: 8, padding: '8px 12px',
+                  background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+                  textAlign: 'center', transition: 'border-color .15s',
+                }}
+                onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+                onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+              />
+              <span style={{ fontSize: 13, color: 'var(--gray2)', fontWeight: 500 }}>dias</span>
+            </div>
+            <div style={{ fontSize: 11, color: 'var(--gray2)', fontWeight: 500, marginTop: 6 }}>1–30 dias entre cada toque.</div>
+          </div>
+        </div>
+      </SectionCard>
+
       {/* ── Cadência ────────────────────────────────────────────── */}
       <SectionCard title="Cadência e horário">
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 24, marginBottom: 24 }}>
 
           <div>
-            <FieldLabel>Intervalo entre contatos</FieldLabel>
+            <FieldLabel>Intervalo entre contatos <span style={{ fontWeight: 500, color: 'var(--gray2)' }}>(legado — em horas, não usado pela campanha)</span></FieldLabel>
             <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
               <input
                 type="number"
@@ -281,6 +407,7 @@ export default function ParametrosPage() {
                   border: '1px solid var(--gray3)', borderRadius: 8, padding: '8px 12px',
                   background: 'var(--bg)', color: 'var(--black)', outline: 'none',
                   textAlign: 'center', transition: 'border-color .15s',
+                  opacity: 0.5,
                 }}
                 onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
                 onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
@@ -463,6 +590,105 @@ export default function ParametrosPage() {
         <div style={{ fontSize: 11, color: 'var(--gray2)', fontWeight: 500, lineHeight: 1.5 }}>
           Enviado como <code style={{ background: 'var(--bg)', padding: '1px 5px', borderRadius: 4, fontFamily: 'monospace', fontSize: 10 }}>Authorization: Bearer</code> no cabeçalho da requisição.{' '}
           Deixe em branco para manter o segredo já salvo.
+        </div>
+
+        <div style={{ height: 1, background: 'var(--gray3)', margin: '24px 0' }} />
+
+        <FieldLabel>URL de disparo (n8n)</FieldLabel>
+        <input
+          type="url"
+          value={n8nDispatchUrl}
+          onChange={e => setN8nDispatchUrl(e.target.value)}
+          placeholder="https://seu-n8n.example.com/webhook/..."
+          style={{
+            width: '100%', fontFamily: 'inherit', fontSize: 13,
+            border: '1px solid var(--gray3)', borderRadius: 10, padding: '10px 14px',
+            background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+            boxSizing: 'border-box', transition: 'border-color .15s', marginBottom: 20,
+          }}
+          onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+          onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+        />
+
+        <FieldLabel>Segredo de disparo (opcional)</FieldLabel>
+        <div style={{ position: 'relative', marginBottom: 8 }}>
+          <input
+            type={showDispatchSecret ? 'text' : 'password'}
+            value={n8nDispatchSecret}
+            onChange={e => setN8nDispatchSecret(e.target.value)}
+            placeholder="••••••••"
+            autoComplete="new-password"
+            style={{
+              width: '100%', fontFamily: 'inherit', fontSize: 13,
+              border: '1px solid var(--gray3)', borderRadius: 10,
+              padding: '10px 42px 10px 14px',
+              background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+              boxSizing: 'border-box', transition: 'border-color .15s',
+            }}
+            onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+            onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+          />
+          <button
+            type="button"
+            onClick={() => setShowDispatchSecret(s => !s)}
+            title={showDispatchSecret ? 'Ocultar' : 'Mostrar'}
+            style={{
+              position: 'absolute', right: 10, top: '50%', transform: 'translateY(-50%)',
+              background: 'none', border: 'none', cursor: 'pointer',
+              color: 'var(--gray2)', padding: 4, display: 'flex', alignItems: 'center',
+            }}
+          >
+            {showDispatchSecret ? <EyeOff size={15} /> : <Eye size={15} />}
+          </button>
+        </div>
+        <div style={{ fontSize: 11, color: 'var(--gray2)', fontWeight: 500, lineHeight: 1.5, marginBottom: 20 }}>
+          Deixe em branco para manter o segredo já salvo.
+        </div>
+
+        <div style={{ fontSize: 12, color: 'var(--gray2)', fontWeight: 500, lineHeight: 1.5, marginBottom: 16 }}>
+          Aciona um ciclo de disparo no n8n para os leads agendados (não escolhe destinatários aqui).
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap' as const }}>
+          <button
+            onClick={dispatch}
+            disabled={dispatching || !n8nDispatchUrl}
+            style={{
+              padding: '10px 22px', borderRadius: 99, fontFamily: 'inherit',
+              fontSize: 13, fontWeight: 800, cursor: (dispatching || !n8nDispatchUrl) ? 'not-allowed' : 'pointer',
+              background: (dispatching || !n8nDispatchUrl) ? 'var(--gray3)' : 'var(--primary)',
+              color: (dispatching || !n8nDispatchUrl) ? 'var(--gray2)' : 'var(--primary-contrast)',
+              border: 'none', transition: 'all .18s', opacity: (dispatching || !n8nDispatchUrl) ? 0.7 : 1,
+            }}
+          >
+            {dispatching ? 'Disparando...' : 'Disparar agora'}
+          </button>
+
+          {dispatchResult !== undefined && dispatchResult.ok && (
+            <div style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              fontSize: 12, fontWeight: 700,
+              background: 'rgba(34,197,94,0.1)', color: 'var(--green)',
+              border: '1px solid rgba(34,197,94,0.25)',
+              borderRadius: 99, padding: '5px 14px',
+            }}>
+              Disparo acionado ✓
+              {dispatchResult.status !== undefined && (
+                <span style={{ fontWeight: 500, opacity: 0.75 }}>· HTTP {dispatchResult.status}</span>
+              )}
+            </div>
+          )}
+          {dispatchResult !== undefined && !dispatchResult.ok && (
+            <div style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              fontSize: 12, fontWeight: 700,
+              background: 'rgba(239,68,68,0.08)', color: 'var(--red)',
+              border: '1px solid rgba(239,68,68,0.25)',
+              borderRadius: 99, padding: '5px 14px',
+            }}>
+              Falha: {dispatchResult.error ?? `HTTP ${dispatchResult.status}`}
+            </div>
+          )}
         </div>
       </SectionCard>
 

--- a/app/api/sdr/dispatch/route.ts
+++ b/app/api/sdr/dispatch/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { campaignSettings } from '@/lib/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { assertEntitlement } from '@/lib/entitlements'
+
+const SOURCE = 'sdr-n8n'
+
+export async function POST() {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { tenantId } = session.user
+  const denied = await assertEntitlement(tenantId, 'sdr.parametros')
+  if (denied) return denied
+
+  const [row] = await db
+    .select()
+    .from(campaignSettings)
+    .where(and(eq(campaignSettings.tenantId, tenantId), eq(campaignSettings.source, SOURCE)))
+    .limit(1)
+
+  let settings: Record<string, unknown> = {}
+  if (row) {
+    try { settings = JSON.parse(row.settings) } catch {}
+  }
+
+  const dispatchUrl =
+    typeof settings.n8nDispatchUrl === 'string' && settings.n8nDispatchUrl
+      ? settings.n8nDispatchUrl
+      : null
+
+  if (!dispatchUrl) {
+    return NextResponse.json({ error: 'dispatch_url_nao_configurada' }, { status: 400 })
+  }
+
+  const dispatchSecret =
+    typeof settings.n8nDispatchSecret === 'string' && settings.n8nDispatchSecret
+      ? settings.n8nDispatchSecret
+      : undefined
+
+  const limiteDiario =
+    typeof settings.limiteDiario === 'number' ? settings.limiteDiario : null
+
+  const payload = {
+    tenantId,
+    triggeredAt: new Date().toISOString(),
+    limiteDiario,
+  }
+
+  try {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (dispatchSecret) headers['Authorization'] = `Bearer ${dispatchSecret}`
+    const res = await fetch(dispatchUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(15_000),
+    })
+    return NextResponse.json({ ok: res.ok, status: res.status })
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err)
+    console.error('[sdr dispatch → n8n]', error)
+    return NextResponse.json({ ok: false, error })
+  }
+}

--- a/app/api/sdr/settings/route.ts
+++ b/app/api/sdr/settings/route.ts
@@ -16,7 +16,12 @@ const DEFAULT_SETTINGS = {
   horario: { inicio: '08:00', fim: '18:00' },
   diasAtivos: [1, 2, 3, 4, 5],
   templates: [''],
+  remetente: '',
+  numToques: 10,
+  intervaloDias: 3,
 }
+
+const E164_RE = /^\+[1-9]\d{6,14}$/
 
 type N8nDeliveryResult = { ok: boolean; status?: number; error?: string }
 
@@ -99,9 +104,9 @@ export async function GET() {
   let parsed: Record<string, unknown> = {}
   try { parsed = JSON.parse(row.settings) } catch {}
 
-  // Omit n8nWebhookSecret from GET response; n8nWebhookUrl is returned for UI display
-  const { n8nWebhookSecret: _omit, ...settingsForClient } = parsed
-  void _omit
+  // Omit secrets from GET response; URLs are returned for UI display
+  const { n8nWebhookSecret: _omitWS, n8nDispatchSecret: _omitDS, ...settingsForClient } = parsed
+  void _omitWS; void _omitDS
 
   return NextResponse.json({ configured: true, status: row.status, version: row.version, settings: settingsForClient })
 }
@@ -141,6 +146,28 @@ export async function PUT(request: Request) {
     }
   }
 
+  // Validate dispatch URL if provided (same anti-SSRF rules)
+  if (rawSettings.n8nDispatchUrl !== undefined && rawSettings.n8nDispatchUrl !== '') {
+    try {
+      validateWebhookUrl(rawSettings.n8nDispatchUrl)
+    } catch (err) {
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : 'n8nDispatchUrl inválida' },
+        { status: 400 },
+      )
+    }
+  }
+
+  // Validate remetente E.164 if provided and non-empty
+  if (rawSettings.remetente !== undefined && rawSettings.remetente !== '') {
+    if (typeof rawSettings.remetente !== 'string' || !E164_RE.test(rawSettings.remetente)) {
+      return NextResponse.json(
+        { error: 'remetente inválido: use formato E.164 (ex: +5511999990000)' },
+        { status: 400 },
+      )
+    }
+  }
+
   const status = body.status as ValidStatus
   const now = new Date()
 
@@ -150,13 +177,16 @@ export async function PUT(request: Request) {
     .where(and(eq(campaignSettings.tenantId, tenantId), eq(campaignSettings.source, SOURCE)))
     .limit(1)
 
-  // Preserve the stored n8nWebhookSecret when the incoming PUT omits or clears it.
-  // (GET strips the secret, so the UI cannot re-send it on subsequent saves.)
-  if (existing && !rawSettings.n8nWebhookSecret) {
+  // Preserve stored secrets when the incoming PUT omits or clears them.
+  // (GET strips secrets, so the UI cannot re-send them on subsequent saves.)
+  if (existing && (!rawSettings.n8nWebhookSecret || !rawSettings.n8nDispatchSecret)) {
     try {
       const stored = JSON.parse(existing.settings) as Record<string, unknown>
-      if (typeof stored.n8nWebhookSecret === 'string' && stored.n8nWebhookSecret) {
+      if (!rawSettings.n8nWebhookSecret && typeof stored.n8nWebhookSecret === 'string' && stored.n8nWebhookSecret) {
         rawSettings.n8nWebhookSecret = stored.n8nWebhookSecret
+      }
+      if (!rawSettings.n8nDispatchSecret && typeof stored.n8nDispatchSecret === 'string' && stored.n8nDispatchSecret) {
+        rawSettings.n8nDispatchSecret = stored.n8nDispatchSecret
       }
     } catch { /* corrupt stored JSON — skip merge */ }
   }
@@ -197,9 +227,15 @@ export async function PUT(request: Request) {
       : undefined
 
   if (webhookUrl) {
-    // Strip webhook config from the payload sent to n8n
-    const { n8nWebhookUrl: _u, n8nWebhookSecret: _s, ...settingsPayload } = rawSettings
-    void _u; void _s
+    // Strip n8n integration config (URLs + secrets) from the payload sent to n8n
+    const {
+      n8nWebhookUrl: _u,
+      n8nWebhookSecret: _s,
+      n8nDispatchUrl: _du,
+      n8nDispatchSecret: _ds,
+      ...settingsPayload
+    } = rawSettings
+    void _u; void _s; void _du; void _ds
     const payload = {
       tenantId,
       status,


### PR DESCRIPTION
- /api/sdr/dispatch: aciona um ciclo de disparo no n8n (POST no webhook
  configurável), com session + assertEntitlement, anti-SSRF na URL, Bearer
  opcional, e nunca derruba (retorna { ok }).
- Parâmetros: seção "Integração n8n" ganha URL de disparo + botão "Disparar agora";
  nova seção "Sequência de disparo" com remetente (E.164), nº de toques e intervalo
  em dias. delay (horas) marcado como legado.
- settings/route.ts: preserva os secrets quando omitidos e remove URLs+secrets do
  n8n (webhook e dispatch) do payload enviado ao n8n.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
