### PR TITLE
fix: dedup de conversas YCloud (n8n é a fonte da conversa)

### DIFF
--- a/app/api/bi/sdr/route.ts
+++ b/app/api/bi/sdr/route.ts
@@ -19,7 +19,7 @@ import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
 import { db } from '@/lib/db'
 import { events, conversations, funnelSnapshots, dataSources } from '@/lib/db/schema'
-import { and, desc, eq, gte, inArray, lte, sql } from 'drizzle-orm'
+import { and, desc, eq, gte, lte, sql } from 'drizzle-orm'
 import { assertEntitlement } from '@/lib/entitlements'
 
 const DAY = 86_400_000
@@ -92,7 +92,9 @@ export async function GET(request: Request) {
     ))
     .groupBy(events.sentiment)
 
-  // ── Conversations: recent sessions across both SDR and WhatsApp sources ───
+  // ── Conversations: recent sessions from supabase-n8n (source of truth for n8n threads) ─
+  //    ycloud-whatsapp is excluded — inbound messages from YCloud no longer write conversation
+  //    rows; n8n_chat_histories (synced via supabase-n8n) is the canonical conversation store.
   //    occurredAt is mode:'timestamp' → Drizzle returns Date; .getTime() = epoch ms
   const convRows = await db
     .select({
@@ -103,7 +105,7 @@ export async function GET(request: Request) {
     .from(conversations)
     .where(and(
       eq(conversations.tenantId, tenantId),
-      inArray(conversations.source, ['supabase-n8n', 'ycloud-whatsapp']),
+      eq(conversations.source, 'supabase-n8n'),
       gte(conversations.occurredAt, periodStart),
     ))
     .orderBy(desc(conversations.occurredAt))

--- a/lib/providers/ycloud.ts
+++ b/lib/providers/ycloud.ts
@@ -4,7 +4,6 @@ import type {
   SyncContext,
   CanonicalBatch,
   CanonicalContact,
-  CanonicalConversation,
   CanonicalEvent,
 } from './types'
 
@@ -271,8 +270,10 @@ function parseMs(iso: string | undefined): number | undefined {
  * Maps a raw YCloud webhook event payload to a CanonicalBatch.
  *
  * Handled event types:
- *   whatsapp.inbound_message.received → CanonicalConversation (role: 'human')
- *                                     + CanonicalContact (externalId = msg.from = E.164 phone)
+ *   whatsapp.inbound_message.received → CanonicalContact only (externalId = msg.from = E.164 phone)
+ *                                       Conversation is NOT emitted — n8n_chat_histories is the
+ *                                       source of truth for conversations (supabase-n8n provider).
+ *                                       Emitting it here caused duplicate conversation rows.
  *   whatsapp.message.updated          → CanonicalEvent (eventType: whatsapp_status_*)
  *
  * The CanonicalContact emitted on each inbound message ensures the contacts table
@@ -296,31 +297,13 @@ export function normalizeWebhookEvent(
       const msg = e.whatsappInboundMessage
       if (!msg?.id || !msg.from) return {}
 
-      // For non-text messages (image, audio, video, …) there is no text.body;
-      // use a bracketed type placeholder so content is never stored empty.
-      const content = msg.text?.body ?? (msg.type ? `[${msg.type}]` : '[unknown]')
-
       const occurredAt = parseMs(msg.sendTime) ?? parseMs(env.createTime)
-
-      const conversation: CanonicalConversation = {
-        sourceId:  msg.id,
-        sessionId: msg.from,          // customer E.164 phone — stable session key
-        role:      'human',
-        content,
-        occurredAt,
-        metadata: {
-          wamid:        msg.wamid,
-          from:         msg.from,
-          to:           msg.to,
-          messageType:  msg.type,
-          customerName: msg.customerProfile?.name,
-          replyToWamid: msg.context?.id,
-        },
-      }
 
       // Upsert a contact so the contacts table stays up-to-date with every inbound message.
       // externalId = msg.from (E.164) = phoneNumber from REST — guaranteed same row, no duplicates.
       // The upsertBatch MAX logic ensures occurredAt only advances, never regresses.
+      // Conversation is intentionally NOT emitted here — n8n writes to n8n_chat_histories,
+      // which the supabase-n8n provider reads as the canonical conversation source.
       const contact: CanonicalContact = {
         externalId: msg.from,
         name:       msg.customerProfile?.name,
@@ -331,7 +314,7 @@ export function normalizeWebhookEvent(
         },
       }
 
-      return { conversations: [conversation], contacts: [contact] }
+      return { contacts: [contact] }
     }
 
     case 'whatsapp.message.updated': {


### PR DESCRIPTION
Como a IA do n8n responde no mesmo número YCloud e grava o thread completo
(human+ai) em n8n_chat_histories (source supabase-n8n), o webhook YCloud para
de gravar conversas inbound pra não duplicar:

- ycloud.ts: normalizeWebhookEvent no inbound passa a emitir só o contato
  (mantém name/phone/lastInteractionAt); não cria mais conversation. Status
  (message.updated) intacto.
- bi/sdr: "sessões recentes" voltam a vir só de supabase-n8n (thread real do n8n).
  Métricas WhatsApp (events/status) inalteradas.

A página /sdr-ia/conversas fica one-sided pro YCloud; torná-la read-only lendo
de supabase-n8n é follow-up.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
