### PR TITLE
feat: teste de disparo YCloud para números selecionados

### DIFF
--- a/app/(app)/sdr-ia/parametros/page.tsx
+++ b/app/(app)/sdr-ia/parametros/page.tsx
@@ -121,6 +121,27 @@ export default function ParametrosPage() {
   const [saveError,          setSaveError]          = useState<string | null>(null)
   const [n8nDelivery,        setN8nDelivery]        = useState<N8nDelivery | undefined>(undefined)
 
+  // ── Teste de disparo ─────────────────────────────────────────────────────────
+  const [testTemplates,    setTestTemplates]    = useState<Array<{ name: string; language: string }>>([])
+  const [testTemplateName, setTestTemplateName] = useState('')
+  const [testLangCode,     setTestLangCode]     = useState('pt_BR')
+  const [testVarsCsv,      setTestVarsCsv]      = useState('')
+  const [testNumbers,      setTestNumbers]      = useState('')
+  const [testSending,      setTestSending]      = useState(false)
+  const [testResults,      setTestResults]      = useState<Array<{ to: string; ok: boolean; id?: string; status?: string; error?: string }> | null>(null)
+  const [testError,        setTestError]        = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch('/api/ycloud/templates')
+      .then(r => r.ok ? r.json() : null)
+      .then((d: { templates?: Array<{ name: string; language: string; status: string }> } | null) => {
+        if (d?.templates) {
+          setTestTemplates(d.templates.filter(t => t.status === 'approved'))
+        }
+      })
+      .catch(() => {})
+  }, [])
+
   useEffect(() => {
     fetch('/api/sdr/settings')
       .then(r => r.ok ? r.json() : Promise.reject(r.status))
@@ -182,6 +203,34 @@ export default function ParametrosPage() {
       setDispatchResult({ ok: false, error: (e as Error).message })
     } finally {
       setDispatching(false)
+    }
+  }
+
+  async function testSend() {
+    const numbers = testNumbers.split('\n').map(s => s.trim()).filter(Boolean)
+    const variaveis = testVarsCsv.split(',').map(s => s.trim()).filter(Boolean)
+    if (!testTemplateName) { setTestError('Escolha ou digite um template'); return }
+    if (numbers.length === 0) { setTestError('Informe pelo menos 1 número'); return }
+    if (numbers.length > 10) { setTestError('Máximo de 10 números por teste'); return }
+    setTestSending(true)
+    setTestResults(null)
+    setTestError(null)
+    try {
+      const res = await fetch('/api/ycloud/test-send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ numbers, templateName: testTemplateName, languageCode: testLangCode || 'pt_BR', variaveis }),
+      })
+      const data = await res.json() as { results?: Array<{ to: string; ok: boolean; id?: string; status?: string; error?: string }>; error?: string }
+      if (!res.ok || !data.results) {
+        setTestError(data.error ?? 'Erro ao enviar')
+      } else {
+        setTestResults(data.results)
+      }
+    } catch (e) {
+      setTestError((e as Error).message)
+    } finally {
+      setTestSending(false)
     }
   }
 
@@ -690,6 +739,153 @@ export default function ParametrosPage() {
             </div>
           )}
         </div>
+      </SectionCard>
+
+      {/* ── Teste de disparo ────────────────────────────────────── */}
+      <SectionCard title="Teste de disparo (números selecionados)">
+        <div style={{
+          display: 'flex', alignItems: 'flex-start', gap: 10,
+          background: 'rgba(239,68,68,0.06)', border: '1px solid rgba(239,68,68,0.22)',
+          borderRadius: 10, padding: '10px 14px', marginBottom: 20,
+          fontSize: 12, color: 'var(--red)', fontWeight: 500, lineHeight: 1.55,
+        }}>
+          ⚠ Envia mensagem <strong style={{ fontWeight: 800 }}>real</strong> (com custo) diretamente via YCloud, somente para os números informados — não usa a fila de campanha.
+        </div>
+
+        <FieldLabel>Template</FieldLabel>
+        {testTemplates.length > 0 && (
+          <select
+            value={testTemplateName}
+            onChange={e => setTestTemplateName(e.target.value)}
+            style={{
+              width: '100%', fontFamily: 'inherit', fontSize: 13,
+              border: '1px solid var(--gray3)', borderRadius: 10, padding: '10px 14px',
+              background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+              boxSizing: 'border-box', transition: 'border-color .15s', marginBottom: 8,
+              cursor: 'pointer',
+            }}
+          >
+            <option value="">— escolha um template aprovado —</option>
+            {testTemplates.map(t => (
+              <option key={`${t.name}:${t.language}`} value={t.name}>{t.name} ({t.language})</option>
+            ))}
+          </select>
+        )}
+        <input
+          type="text"
+          value={testTemplateName}
+          onChange={e => setTestTemplateName(e.target.value)}
+          placeholder="nome_do_template (ou digite manualmente)"
+          style={{
+            width: '100%', fontFamily: 'inherit', fontSize: 13,
+            border: '1px solid var(--gray3)', borderRadius: 10, padding: '10px 14px',
+            background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+            boxSizing: 'border-box', transition: 'border-color .15s', marginBottom: 20,
+          }}
+          onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+          onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+        />
+
+        <div style={{ display: 'grid', gridTemplateColumns: '120px 1fr', gap: 16, marginBottom: 20 }}>
+          <div>
+            <FieldLabel>Idioma</FieldLabel>
+            <input
+              type="text"
+              value={testLangCode}
+              onChange={e => setTestLangCode(e.target.value)}
+              placeholder="pt_BR"
+              style={{
+                width: '100%', fontFamily: 'inherit', fontSize: 13,
+                border: '1px solid var(--gray3)', borderRadius: 10, padding: '10px 14px',
+                background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+                boxSizing: 'border-box', transition: 'border-color .15s',
+              }}
+              onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+              onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+            />
+          </div>
+          <div>
+            <FieldLabel>Variáveis (separadas por vírgula)</FieldLabel>
+            <input
+              type="text"
+              value={testVarsCsv}
+              onChange={e => setTestVarsCsv(e.target.value)}
+              placeholder="João Silva, Empresa Ltda"
+              style={{
+                width: '100%', fontFamily: 'inherit', fontSize: 13,
+                border: '1px solid var(--gray3)', borderRadius: 10, padding: '10px 14px',
+                background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+                boxSizing: 'border-box', transition: 'border-color .15s',
+              }}
+              onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+              onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+            />
+            <div style={{ fontSize: 11, color: 'var(--gray2)', fontWeight: 500, marginTop: 5 }}>
+              Preencha conforme as variáveis do template; a maioria usa 1 (nome).
+            </div>
+          </div>
+        </div>
+
+        <FieldLabel>Números — 1 por linha (E.164)</FieldLabel>
+        <textarea
+          value={testNumbers}
+          onChange={e => setTestNumbers(e.target.value)}
+          rows={4}
+          placeholder={'+5554999990000\n+5551988880000'}
+          style={{
+            width: '100%', fontFamily: 'monospace', fontSize: 13,
+            border: '1px solid var(--gray3)', borderRadius: 10, padding: '10px 14px',
+            background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+            boxSizing: 'border-box', resize: 'vertical', lineHeight: 1.6,
+            transition: 'border-color .15s', marginBottom: 4,
+          }}
+          onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+          onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+        />
+        <div style={{ fontSize: 11, color: 'var(--gray2)', fontWeight: 500, marginBottom: 18 }}>
+          Máximo de 10 números por teste.
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 18, flexWrap: 'wrap' as const }}>
+          <button
+            onClick={testSend}
+            disabled={testSending}
+            style={{
+              padding: '10px 22px', borderRadius: 99, fontFamily: 'inherit',
+              fontSize: 13, fontWeight: 800, cursor: testSending ? 'not-allowed' : 'pointer',
+              background: testSending ? 'var(--gray3)' : 'var(--primary)',
+              color: testSending ? 'var(--gray2)' : 'var(--primary-contrast)',
+              border: 'none', transition: 'all .18s', opacity: testSending ? 0.7 : 1,
+            }}
+          >
+            {testSending ? 'Enviando...' : 'Enviar teste'}
+          </button>
+          {testError && (
+            <span style={{ fontSize: 13, fontWeight: 700, color: 'var(--red)' }}>✗ {testError}</span>
+          )}
+        </div>
+
+        {testResults && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {testResults.map((r, i) => (
+              <div key={i} style={{
+                display: 'flex', alignItems: 'center', gap: 10,
+                background: r.ok ? 'rgba(34,197,94,0.08)' : 'rgba(239,68,68,0.08)',
+                border: `1px solid ${r.ok ? 'rgba(34,197,94,0.25)' : 'rgba(239,68,68,0.25)'}`,
+                borderRadius: 10, padding: '8px 14px',
+              }}>
+                <span style={{ fontWeight: 800, color: r.ok ? 'var(--green)' : 'var(--red)', flexShrink: 0, fontSize: 14 }}>
+                  {r.ok ? '✓' : '✗'}
+                </span>
+                <code style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--black)', flexShrink: 0 }}>{r.to}</code>
+                {r.ok
+                  ? <span style={{ fontSize: 12, color: 'var(--gray2)', fontWeight: 500 }}>id: {r.id}</span>
+                  : <span style={{ fontSize: 12, color: 'var(--red)', fontWeight: 500 }}>{r.error}</span>
+                }
+              </div>
+            ))}
+          </div>
+        )}
       </SectionCard>
 
       {/* ── Conexão (link, não duplica a fonte) ─────────────────── */}

--- a/app/api/ycloud/test-send/route.ts
+++ b/app/api/ycloud/test-send/route.ts
@@ -1,0 +1,111 @@
+// POST /api/ycloud/test-send
+//
+// Envia um template WhatsApp diretamente via YCloud para uma lista de números
+// fornecidos pelo usuário. NÃO usa a fila de campanha (lead_actions).
+//
+// Body:  { numbers: string[], templateName: string, languageCode?: string, variaveis?: string[] }
+// Response: { results: { to, ok, id?, status?, error? }[] }
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { dataSources } from '@/lib/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { decrypt } from '@/lib/crypto'
+import { assertEntitlement } from '@/lib/entitlements'
+import { yCloudProvider, sendWhatsappMessage } from '@/lib/providers/ycloud'
+
+const PROVIDER_KEY = 'ycloud-whatsapp'
+const MODULE_KEY   = 'integration.ycloud-whatsapp'
+const E164_RE      = /^\+[1-9]\d{6,14}$/
+const MAX_NUMBERS  = 10
+
+export async function POST(request: Request) {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { tenantId } = session.user
+  const denied = await assertEntitlement(tenantId, MODULE_KEY)
+  if (denied) return denied
+
+  let body: { numbers?: unknown; templateName?: unknown; languageCode?: unknown; variaveis?: unknown }
+  try { body = await request.json() } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const templateName = typeof body.templateName === 'string' ? body.templateName.trim() : ''
+  if (!templateName) {
+    return NextResponse.json({ error: 'templateName é obrigatório' }, { status: 400 })
+  }
+
+  if (!Array.isArray(body.numbers) || body.numbers.length === 0) {
+    return NextResponse.json({ error: 'numbers deve ser um array não vazio' }, { status: 400 })
+  }
+  if (body.numbers.length > MAX_NUMBERS) {
+    return NextResponse.json(
+      { error: `máximo de ${MAX_NUMBERS} números por teste` },
+      { status: 400 },
+    )
+  }
+
+  const languageCode =
+    typeof body.languageCode === 'string' && body.languageCode
+      ? body.languageCode
+      : 'pt_BR'
+
+  const variaveis: string[] = Array.isArray(body.variaveis)
+    ? body.variaveis.filter((v): v is string => typeof v === 'string')
+    : []
+
+  // Load YCloud config for this tenant
+  const row = await db
+    .select()
+    .from(dataSources)
+    .where(and(
+      eq(dataSources.tenantId, tenantId),
+      eq(dataSources.providerKey, PROVIDER_KEY),
+    ))
+    .then(r => r[0])
+
+  if (!row?.configEnc) {
+    return NextResponse.json({ error: 'ycloud_nao_configurado' }, { status: 400 })
+  }
+
+  let cfg: ReturnType<typeof yCloudProvider.parseConfig>
+  try {
+    cfg = yCloudProvider.parseConfig(JSON.parse(decrypt(row.configEnc)))
+  } catch (err) {
+    return NextResponse.json(
+      { error: 'config_invalid', message: (err as Error).message },
+      { status: 500 },
+    )
+  }
+
+  const components = variaveis.length > 0
+    ? [{ type: 'body', parameters: variaveis.map(text => ({ type: 'text', text })) }]
+    : undefined
+
+  // Send to each number in parallel — per-number errors don't abort the batch
+  const results = await Promise.all(
+    (body.numbers as unknown[]).map(async (raw) => {
+      const to = typeof raw === 'string' ? raw.trim() : ''
+      if (!E164_RE.test(to)) {
+        return { to: to || String(raw), ok: false, error: 'número inválido (E.164 esperado)' }
+      }
+      try {
+        const sent = await sendWhatsappMessage(cfg, {
+          to,
+          type:         'template',
+          templateName,
+          languageCode,
+          components,
+        })
+        return { to, ok: true, id: sent.id, status: sent.status }
+      } catch (err) {
+        return { to, ok: false, error: (err as Error).message }
+      }
+    })
+  )
+
+  return NextResponse.json({ results })
+}


### PR DESCRIPTION
Envio de teste que manda um template aprovado direto pela API do YCloud para
até 10 números informados, sem passar pela fila de campanha (lead_actions).

- /api/ycloud/test-send: session + assertEntitlement(integration.ycloud-whatsapp);
  valida E.164 por número (inválido não derruba o lote), cap de 10, omite
  components quando sem variáveis; resultado por número { to, ok, id?, error? }.
- Parâmetros: card "Teste de disparo" com seletor de template (aprovados) +
  override manual, campo de variáveis, números (1 por linha) e resultado por número.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
