### PR TITLE
feat: enrollment manual de leads (seleção na plataforma -> fila n8n)

### DIFF
--- a/app/(app)/sdr-ia/layout.tsx
+++ b/app/(app)/sdr-ia/layout.tsx
@@ -6,6 +6,7 @@ import { useModules } from '@/components/ModulesProvider'
 const TABS = [
   { href: '/sdr-ia/dashboard',  label: 'Dashboard',  moduleKey: 'sdr.dashboard'               },
   { href: '/sdr-ia/parametros', label: 'Parâmetros', moduleKey: 'sdr.parametros'              },
+  { href: '/sdr-ia/leads',      label: 'Leads',      moduleKey: 'sdr.parametros'              },
   { href: '/sdr-ia/contatos',   label: 'Contatos',   moduleKey: 'integration.ycloud-whatsapp' },
   { href: '/sdr-ia/conversas',  label: 'Conversas',  moduleKey: 'integration.ycloud-whatsapp' },
 ]

--- a/app/(app)/sdr-ia/leads/page.tsx
+++ b/app/(app)/sdr-ia/leads/page.tsx
@@ -1,0 +1,380 @@
+'use client'
+import { useEffect, useRef, useState } from 'react'
+import { Search } from 'lucide-react'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface LeadItem {
+  id:      string
+  name:    string | null
+  phone:   string | null
+  company: string | null
+  source:  string | null
+  status:  string | null
+  ativo:   boolean | null
+}
+
+interface ApiResponse {
+  items: LeadItem[]
+  page:  number
+  limit: number
+  total: number
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const LIMIT = 50
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function StatusBadge({ value }: { value: string | null }) {
+  if (!value) return <span style={{ color: 'var(--gray3)', fontSize: 11 }}>—</span>
+  const colors: Record<string, { bg: string; color: string }> = {
+    ativo:     { bg: 'rgba(34,197,94,0.10)',  color: '#15803d' },
+    inativo:   { bg: 'rgba(239,68,68,0.08)',  color: 'var(--red)' },
+    qualificado: { bg: 'rgba(37,99,235,0.10)', color: '#1d4ed8' },
+  }
+  const style = colors[value.toLowerCase()] ?? { bg: 'rgba(0,0,0,0.05)', color: 'var(--gray)' }
+  return (
+    <span style={{
+      fontSize: 10, fontWeight: 700, padding: '2px 8px', borderRadius: 99,
+      background: style.bg, color: style.color,
+      border: `1px solid ${style.color}30`,
+    }}>
+      {value}
+    </span>
+  )
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function LeadsPage() {
+  const [data,      setData]      = useState<ApiResponse | null>(null)
+  const [loading,   setLoading]   = useState(true)
+  const [error,     setError]     = useState<string | null>(null)
+  const [page,      setPage]      = useState(1)
+  const [q,         setQ]         = useState('')
+  const [debQ,      setDebQ]      = useState('')
+  const [selected,  setSelected]  = useState<Set<string>>(new Set())
+  const [enrolling, setEnrolling] = useState(false)
+  const [enrollResult, setEnrollResult] = useState<{ ok: boolean; enrolled?: number; error?: string } | null>(null)
+
+  const masterRef = useRef<HTMLInputElement>(null)
+
+  // Debounce search
+  useEffect(() => {
+    const t = setTimeout(() => setDebQ(q), 350)
+    return () => clearTimeout(t)
+  }, [q])
+
+  // Reset page on search change
+  useEffect(() => { setPage(1) }, [debQ])
+
+  // Clear enroll feedback when page/search changes
+  useEffect(() => { setEnrollResult(null) }, [page, debQ])
+
+  // Fetch leads
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+
+    const params = new URLSearchParams({ page: String(page), limit: String(LIMIT) })
+    if (debQ) params.set('q', debQ)
+
+    fetch(`/api/sdr/leads?${params}`)
+      .then(r => r.ok ? r.json() : r.json().then((d: { error?: string }) => Promise.reject(d.error ?? r.status)))
+      .then((d: ApiResponse) => { if (!cancelled) { setData(d); setLoading(false) } })
+      .catch((e: unknown) => { if (!cancelled) { setError(String(e)); setLoading(false) } })
+
+    return () => { cancelled = true }
+  }, [page, debQ])
+
+  // Keep master checkbox indeterminate state in sync
+  const pageIds  = data?.items.map(i => i.id) ?? []
+  const selCount = pageIds.filter(id => selected.has(id)).length
+  const allOnPage = pageIds.length > 0 && selCount === pageIds.length
+  const someOnPage = selCount > 0 && selCount < pageIds.length
+
+  useEffect(() => {
+    if (masterRef.current) masterRef.current.indeterminate = someOnPage
+  }, [someOnPage])
+
+  function toggleAll() {
+    setSelected(prev => {
+      const next = new Set(prev)
+      if (allOnPage) { pageIds.forEach(id => next.delete(id)) }
+      else            { pageIds.forEach(id => next.add(id)) }
+      return next
+    })
+  }
+
+  function toggleOne(id: string) {
+    setSelected(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id); else next.add(id)
+      return next
+    })
+  }
+
+  async function enroll() {
+    const leadIds = Array.from(selected)
+    if (leadIds.length === 0) return
+    setEnrolling(true)
+    setEnrollResult(null)
+    try {
+      const res = await fetch('/api/sdr/enroll', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ leadIds }),
+      })
+      const data = await res.json() as { ok: boolean; enrolled?: number; status?: number; error?: string }
+      if (res.ok && data.ok) {
+        setEnrollResult({ ok: true, enrolled: data.enrolled ?? leadIds.length })
+        setSelected(new Set())
+      } else {
+        setEnrollResult({ ok: false, error: data.error ?? `HTTP ${data.status ?? res.status}` })
+      }
+    } catch (e) {
+      setEnrollResult({ ok: false, error: (e as Error).message })
+    } finally {
+      setEnrolling(false)
+    }
+  }
+
+  const total      = data?.total ?? 0
+  const totalPages = Math.max(1, Math.ceil(total / LIMIT))
+  const hasPrev    = page > 1
+  const hasNext    = page < totalPages
+
+  return (
+    <div>
+
+      {/* ── Header ─────────────────────────────────────────────────── */}
+      <div style={{
+        display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between',
+        flexWrap: 'wrap', gap: 16, marginBottom: 24,
+      }}>
+        <div>
+          <div style={{ fontSize: 22, fontWeight: 800, color: 'var(--black)', letterSpacing: '-0.02em', marginBottom: 4 }}>
+            Leads
+          </div>
+          <div style={{ fontSize: 13, color: 'var(--gray)' }}>
+            Selecione leads para adicioná-los à campanha de disparo.
+          </div>
+        </div>
+
+        {/* Search */}
+        <div style={{ position: 'relative' }}>
+          <Search size={14} style={{
+            position: 'absolute', left: 12, top: '50%', transform: 'translateY(-50%)',
+            color: 'var(--gray2)', pointerEvents: 'none',
+          }} />
+          <input
+            value={q}
+            onChange={e => setQ(e.target.value)}
+            placeholder="Nome, telefone ou empresa..."
+            style={{
+              paddingLeft: 34, paddingRight: 14, paddingTop: 9, paddingBottom: 9,
+              fontSize: 13, fontFamily: 'inherit', fontWeight: 500,
+              border: '1px solid var(--gray3)', borderRadius: 99,
+              background: 'var(--white)', color: 'var(--black)',
+              outline: 'none', transition: 'border-color .15s', minWidth: 240,
+            }}
+            onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+            onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+          />
+        </div>
+      </div>
+
+      {/* ── Enroll bar ─────────────────────────────────────────────── */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 14,
+        marginBottom: 16, flexWrap: 'wrap' as const,
+      }}>
+        <button
+          onClick={enroll}
+          disabled={enrolling || selected.size === 0}
+          style={{
+            padding: '9px 22px', borderRadius: 99, fontFamily: 'inherit',
+            fontSize: 13, fontWeight: 800,
+            cursor: (enrolling || selected.size === 0) ? 'not-allowed' : 'pointer',
+            background: (enrolling || selected.size === 0) ? 'var(--gray3)' : 'var(--primary)',
+            color: (enrolling || selected.size === 0) ? 'var(--gray2)' : 'var(--primary-contrast)',
+            border: 'none', transition: 'all .18s',
+            opacity: (enrolling || selected.size === 0) ? 0.65 : 1,
+          }}
+        >
+          {enrolling ? 'Adicionando...' : `Adicionar à campanha${selected.size > 0 ? ` (${selected.size})` : ''}`}
+        </button>
+
+        {enrollResult?.ok && (
+          <span style={{ fontSize: 13, fontWeight: 700, color: 'var(--green)' }}>
+            ✓ {enrollResult.enrolled ?? selected.size} leads adicionados
+          </span>
+        )}
+        {enrollResult && !enrollResult.ok && (
+          <span style={{ fontSize: 13, fontWeight: 700, color: 'var(--red)' }}>
+            ✗ {enrollResult.error}
+          </span>
+        )}
+
+        {!enrollResult && (
+          <span style={{ fontSize: 12, color: 'var(--gray2)', fontWeight: 500 }}>
+            Os leads selecionados entram na fila de disparo (Template 1).
+          </span>
+        )}
+      </div>
+
+      {/* ── Status line ────────────────────────────────────────────── */}
+      {!loading && !error && data && (
+        <div style={{ fontSize: 12, color: 'var(--gray2)', fontWeight: 500, marginBottom: 12 }}>
+          {total.toLocaleString('pt-BR')} lead{total !== 1 ? 's' : ''}
+          {debQ && ` para "${debQ}"`}
+          {totalPages > 1 && ` — página ${page} de ${totalPages}`}
+        </div>
+      )}
+
+      {/* ── Loading ────────────────────────────────────────────────── */}
+      {loading && (
+        <div style={{ padding: '48px 0', textAlign: 'center', fontSize: 13, color: 'var(--gray2)' }}>
+          Carregando...
+        </div>
+      )}
+
+      {/* ── Error ──────────────────────────────────────────────────── */}
+      {!loading && error && (
+        <div style={{ padding: '48px 0', textAlign: 'center' }}>
+          <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--red)', marginBottom: 8 }}>
+            Falha ao carregar leads
+          </div>
+          <div style={{ fontSize: 13, color: 'var(--gray2)' }}>
+            {error === 'fonte_sdr_nao_configurada'
+              ? 'Configure a fonte de dados SDR (Supabase / n8n) primeiro.'
+              : error}
+          </div>
+        </div>
+      )}
+
+      {/* ── Table ──────────────────────────────────────────────────── */}
+      {!loading && !error && (
+        <div style={{
+          background: 'var(--white)', borderRadius: 16,
+          border: '1px solid var(--gray3)', overflow: 'hidden',
+        }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ background: 'var(--bg)' }}>
+                <th style={{ padding: '9px 16px', borderBottom: '1px solid var(--gray3)', width: 40 }}>
+                  <input
+                    ref={masterRef}
+                    type="checkbox"
+                    checked={allOnPage}
+                    onChange={toggleAll}
+                    disabled={pageIds.length === 0}
+                    style={{ cursor: 'pointer', accentColor: 'var(--primary)' }}
+                  />
+                </th>
+                {(['Nome', 'Telefone', 'Empresa', 'Origem', 'Status'] as const).map(col => (
+                  <th key={col} style={{
+                    padding: '9px 16px', textAlign: 'left',
+                    fontSize: 10, fontWeight: 800, color: 'var(--gray2)',
+                    textTransform: 'uppercase', letterSpacing: '0.07em',
+                    borderBottom: '1px solid var(--gray3)', whiteSpace: 'nowrap',
+                  }}>
+                    {col}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {(data?.items ?? []).length === 0 ? (
+                <tr>
+                  <td colSpan={6} style={{ padding: '32px 20px', textAlign: 'center', fontSize: 13, color: 'var(--gray2)' }}>
+                    {debQ ? `Nenhum lead encontrado para "${debQ}"` : 'Nenhum lead encontrado'}
+                  </td>
+                </tr>
+              ) : (data?.items ?? []).map((lead, i) => {
+                const checked = selected.has(lead.id)
+                const isLast = i === (data?.items.length ?? 0) - 1
+                return (
+                  <tr
+                    key={lead.id}
+                    onClick={() => toggleOne(lead.id)}
+                    style={{
+                      borderBottom: isLast ? 'none' : '1px solid var(--gray3)',
+                      background: checked ? 'var(--primary-dim)' : 'transparent',
+                      borderLeft: `3px solid ${checked ? 'var(--primary)' : 'transparent'}`,
+                      cursor: 'pointer', transition: 'background .12s, border-color .12s',
+                    }}
+                  >
+                    <td style={{ padding: '11px 16px' }} onClick={e => e.stopPropagation()}>
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => toggleOne(lead.id)}
+                        style={{ cursor: 'pointer', accentColor: 'var(--primary)' }}
+                      />
+                    </td>
+                    <td style={{ padding: '11px 16px', fontSize: 13, fontWeight: 700, color: 'var(--black)' }}>
+                      {lead.name || '—'}
+                    </td>
+                    <td style={{ padding: '11px 16px' }}>
+                      <span style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--gray)' }}>
+                        {lead.phone || '—'}
+                      </span>
+                    </td>
+                    <td style={{ padding: '11px 16px', fontSize: 13, color: 'var(--gray)', fontWeight: 500 }}>
+                      {lead.company || '—'}
+                    </td>
+                    <td style={{ padding: '11px 16px', fontSize: 12, color: 'var(--gray2)', fontWeight: 500 }}>
+                      {lead.source || '—'}
+                    </td>
+                    <td style={{ padding: '11px 16px' }}>
+                      <StatusBadge value={lead.status} />
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* ── Pagination ─────────────────────────────────────────────── */}
+      {!loading && !error && totalPages > 1 && (
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 12, marginTop: 20 }}>
+          <button
+            onClick={() => setPage(p => p - 1)}
+            disabled={!hasPrev}
+            style={{
+              padding: '8px 18px', borderRadius: 99, fontFamily: 'inherit',
+              fontSize: 13, fontWeight: 700,
+              cursor: hasPrev ? 'pointer' : 'not-allowed',
+              border: '1px solid var(--gray3)', background: 'var(--white)',
+              color: hasPrev ? 'var(--black)' : 'var(--gray3)',
+            }}
+          >
+            ← Anterior
+          </button>
+          <span style={{ fontSize: 12, color: 'var(--gray2)', fontWeight: 500 }}>
+            {page} / {totalPages}
+          </span>
+          <button
+            onClick={() => setPage(p => p + 1)}
+            disabled={!hasNext}
+            style={{
+              padding: '8px 18px', borderRadius: 99, fontFamily: 'inherit',
+              fontSize: 13, fontWeight: 700,
+              cursor: hasNext ? 'pointer' : 'not-allowed',
+              border: '1px solid var(--gray3)', background: 'var(--white)',
+              color: hasNext ? 'var(--black)' : 'var(--gray3)',
+            }}
+          >
+            Próxima →
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/(app)/sdr-ia/parametros/page.tsx
+++ b/app/(app)/sdr-ia/parametros/page.tsx
@@ -22,6 +22,7 @@ interface Settings {
   intervaloDias:    number   // 1–30, intervalo entre toques
   n8nWebhookUrl?:   string  // returned by GET; extracted to separate state on load
   n8nDispatchUrl?:  string  // returned by GET; extracted to separate state on load
+  n8nEnrollUrl?:    string  // returned by GET; extracted to separate state on load
 }
 
 interface ApiData {
@@ -114,6 +115,9 @@ export default function ParametrosPage() {
   const [showDispatchSecret, setShowDispatchSecret] = useState(false)
   const [dispatching,        setDispatching]        = useState(false)
   const [dispatchResult,     setDispatchResult]     = useState<{ ok: boolean; status?: number; error?: string } | undefined>(undefined)
+  const [n8nEnrollUrl,       setN8nEnrollUrl]       = useState('')
+  const [n8nEnrollSecret,    setN8nEnrollSecret]    = useState('')
+  const [showEnrollSecret,   setShowEnrollSecret]   = useState(false)
   const [remetenteError,     setRemetenteError]     = useState<string | null>(null)
   const [loading,            setLoading]            = useState(true)
   const [saving,             setSaving]             = useState(false)
@@ -146,11 +150,12 @@ export default function ParametrosPage() {
     fetch('/api/sdr/settings')
       .then(r => r.ok ? r.json() : Promise.reject(r.status))
       .then((d: ApiData) => {
-        const { n8nWebhookUrl: webhookUrl, n8nDispatchUrl: dispatchUrl, ...coreSettings } = d.settings
+        const { n8nWebhookUrl: webhookUrl, n8nDispatchUrl: dispatchUrl, n8nEnrollUrl: enrollUrl, ...coreSettings } = d.settings
         setSettings({ ...DEFAULTS, ...coreSettings })
         setStatus(d.status)
         setN8nWebhookUrl(webhookUrl ?? '')
         setN8nDispatchUrl(dispatchUrl ?? '')
+        setN8nEnrollUrl(enrollUrl ?? '')
         // secrets are never returned by GET — fields stay empty intentionally
       })
       .catch(() => {})
@@ -174,6 +179,8 @@ export default function ParametrosPage() {
         ...(n8nWebhookSecret  ? { n8nWebhookSecret }  : {}),
         n8nDispatchUrl,
         ...(n8nDispatchSecret ? { n8nDispatchSecret } : {}),
+        n8nEnrollUrl,
+        ...(n8nEnrollSecret ? { n8nEnrollSecret } : {}),
       }
       const res = await fetch('/api/sdr/settings', {
         method: 'PUT',
@@ -738,6 +745,59 @@ export default function ParametrosPage() {
               Falha: {dispatchResult.error ?? `HTTP ${dispatchResult.status}`}
             </div>
           )}
+        </div>
+
+        <div style={{ height: 1, background: 'var(--gray3)', margin: '24px 0' }} />
+
+        <FieldLabel>URL de enrollment (n8n)</FieldLabel>
+        <input
+          type="url"
+          value={n8nEnrollUrl}
+          onChange={e => setN8nEnrollUrl(e.target.value)}
+          placeholder="https://seu-n8n.example.com/webhook/..."
+          style={{
+            width: '100%', fontFamily: 'inherit', fontSize: 13,
+            border: '1px solid var(--gray3)', borderRadius: 10, padding: '10px 14px',
+            background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+            boxSizing: 'border-box', transition: 'border-color .15s', marginBottom: 20,
+          }}
+          onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+          onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+        />
+
+        <FieldLabel>Segredo de enrollment (opcional)</FieldLabel>
+        <div style={{ position: 'relative', marginBottom: 8 }}>
+          <input
+            type={showEnrollSecret ? 'text' : 'password'}
+            value={n8nEnrollSecret}
+            onChange={e => setN8nEnrollSecret(e.target.value)}
+            placeholder="••••••••"
+            autoComplete="new-password"
+            style={{
+              width: '100%', fontFamily: 'inherit', fontSize: 13,
+              border: '1px solid var(--gray3)', borderRadius: 10,
+              padding: '10px 42px 10px 14px',
+              background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+              boxSizing: 'border-box', transition: 'border-color .15s',
+            }}
+            onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+            onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+          />
+          <button
+            type="button"
+            onClick={() => setShowEnrollSecret(s => !s)}
+            title={showEnrollSecret ? 'Ocultar' : 'Mostrar'}
+            style={{
+              position: 'absolute', right: 10, top: '50%', transform: 'translateY(-50%)',
+              background: 'none', border: 'none', cursor: 'pointer',
+              color: 'var(--gray2)', padding: 4, display: 'flex', alignItems: 'center',
+            }}
+          >
+            {showEnrollSecret ? <EyeOff size={15} /> : <Eye size={15} />}
+          </button>
+        </div>
+        <div style={{ fontSize: 11, color: 'var(--gray2)', fontWeight: 500, lineHeight: 1.5 }}>
+          Webhook acionado pela página Leads ao adicionar leads à campanha. Deixe em branco para manter o segredo já salvo.
         </div>
       </SectionCard>
 

--- a/app/api/sdr/enroll/route.ts
+++ b/app/api/sdr/enroll/route.ts
@@ -1,0 +1,105 @@
+// POST /api/sdr/enroll
+//
+// Envia leadIds ao webhook de enrollment do n8n, que é responsável por criar
+// as lead_actions. A plataforma NÃO escreve no Postgres/Supabase.
+//
+// Body:     { leadIds: string[], fase?: string, agendarPara?: string }
+// Response: { ok: boolean, status?: number, enrolled?: number, error?: string }
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { campaignSettings } from '@/lib/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { assertEntitlement } from '@/lib/entitlements'
+
+const SOURCE      = 'sdr-n8n'
+const MAX_LEADS   = 100
+const UUID_RE     = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export async function POST(request: Request) {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { tenantId } = session.user
+  const denied = await assertEntitlement(tenantId, 'sdr.parametros')
+  if (denied) return denied
+
+  let body: { leadIds?: unknown; fase?: unknown; agendarPara?: unknown }
+  try { body = await request.json() } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  if (!Array.isArray(body.leadIds) || body.leadIds.length === 0) {
+    return NextResponse.json({ error: 'leadIds deve ser um array não vazio' }, { status: 400 })
+  }
+  if (body.leadIds.length > MAX_LEADS) {
+    return NextResponse.json({ error: `máximo de ${MAX_LEADS} leads por enrollment` }, { status: 400 })
+  }
+
+  // Filter to valid UUIDs — silently drop invalid entries
+  const leadIds = (body.leadIds as unknown[])
+    .filter((id): id is string => typeof id === 'string' && UUID_RE.test(id))
+
+  if (leadIds.length === 0) {
+    return NextResponse.json({ error: 'nenhum leadId válido (UUID esperado)' }, { status: 400 })
+  }
+
+  const fase        = typeof body.fase === 'string' && body.fase ? body.fase : 'Template 1'
+  const agendarPara = typeof body.agendarPara === 'string' && body.agendarPara ? body.agendarPara : undefined
+
+  // Load enrollment URL + secret from campaign settings
+  const [row] = await db
+    .select()
+    .from(campaignSettings)
+    .where(and(eq(campaignSettings.tenantId, tenantId), eq(campaignSettings.source, SOURCE)))
+    .limit(1)
+
+  let settings: Record<string, unknown> = {}
+  if (row) {
+    try { settings = JSON.parse(row.settings) } catch {}
+  }
+
+  const enrollUrl =
+    typeof settings.n8nEnrollUrl === 'string' && settings.n8nEnrollUrl
+      ? settings.n8nEnrollUrl
+      : null
+
+  if (!enrollUrl) {
+    return NextResponse.json({ error: 'enroll_url_nao_configurada' }, { status: 400 })
+  }
+
+  const enrollSecret =
+    typeof settings.n8nEnrollSecret === 'string' && settings.n8nEnrollSecret
+      ? settings.n8nEnrollSecret
+      : undefined
+
+  const payload = { tenantId, leadIds, fase, ...(agendarPara ? { agendarPara } : {}) }
+
+  try {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (enrollSecret) headers['Authorization'] = `Bearer ${enrollSecret}`
+
+    const res = await fetch(enrollUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(15_000),
+    })
+
+    // Try to extract enrolled count if n8n returns it
+    let enrolled: number | undefined
+    try {
+      const data = await res.json() as Record<string, unknown>
+      if (typeof data.enrolled === 'number') enrolled = data.enrolled
+      else if (typeof data.count === 'number')    enrolled = data.count
+      else if (Array.isArray(data.created))       enrolled = data.created.length
+    } catch { /* n8n response not JSON or no count field */ }
+
+    return NextResponse.json({ ok: res.ok, status: res.status, enrolled })
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err)
+    console.error('[sdr enroll → n8n]', error)
+    return NextResponse.json({ ok: false, error })
+  }
+}

--- a/app/api/sdr/leads/route.ts
+++ b/app/api/sdr/leads/route.ts
@@ -1,0 +1,136 @@
+// GET /api/sdr/leads?q=&source=&status=&page=1&limit=50
+//
+// Lista leads da tabela `leads` no Supabase (SOMENTE SELECT — nunca escreve).
+// Connection string obtida do data_source do tenant (providerKey='supabase-n8n'),
+// decifrada em runtime — nunca exposta ao cliente.
+//
+// Response: { items: LeadItem[], page: number, limit: number, total: number }
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { dataSources } from '@/lib/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { decrypt } from '@/lib/crypto'
+import { assertEntitlement } from '@/lib/entitlements'
+import { Client } from 'pg'
+
+const PROVIDER_KEY = 'supabase-n8n'
+const MAX_LIMIT    = 50
+
+interface LeadRow {
+  id:             string
+  name:           string | null
+  phone:          string | null
+  phone_adjusted: string | null
+  company:        string | null
+  source:         string | null
+  status:         string | null
+  ativo:          boolean | null
+  dealid:         string | null
+}
+
+export async function GET(request: Request) {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { tenantId } = session.user
+  const denied = await assertEntitlement(tenantId, 'sdr.parametros')
+  if (denied) return denied
+
+  const { searchParams } = new URL(request.url)
+  const q      = searchParams.get('q')?.trim() ?? ''
+  const source = searchParams.get('source')?.trim() ?? ''
+  const status = searchParams.get('status')?.trim() ?? ''
+  const page   = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10))
+  const limit  = Math.min(MAX_LIMIT, Math.max(1, parseInt(searchParams.get('limit') ?? '50', 10)))
+  const offset = (page - 1) * limit
+
+  // Load Supabase connection string from the tenant's data source
+  const row = await db
+    .select()
+    .from(dataSources)
+    .where(and(
+      eq(dataSources.tenantId, tenantId),
+      eq(dataSources.providerKey, PROVIDER_KEY),
+    ))
+    .then(r => r[0])
+
+  if (!row?.configEnc) {
+    return NextResponse.json({ error: 'fonte_sdr_nao_configurada' }, { status: 400 })
+  }
+
+  let connectionString: string
+  try {
+    const cfg = JSON.parse(decrypt(row.configEnc)) as { connectionString?: string }
+    if (!cfg.connectionString) throw new Error('connectionString ausente')
+    connectionString = cfg.connectionString
+  } catch (err) {
+    return NextResponse.json(
+      { error: 'config_invalid', message: (err as Error).message },
+      { status: 500 },
+    )
+  }
+
+  const client = new Client({ connectionString })
+  try {
+    await client.connect()
+
+    // Build parameterized WHERE clause — never interpolate user input into SQL
+    const conditions: string[] = []
+    const params: unknown[]    = []
+    let idx = 1
+
+    if (q) {
+      conditions.push(`(name ILIKE $${idx} OR phone ILIKE $${idx + 1} OR company ILIKE $${idx + 2})`)
+      params.push(`%${q}%`, `%${q}%`, `%${q}%`)
+      idx += 3
+    }
+    if (source) {
+      conditions.push(`source = $${idx++}`)
+      params.push(source)
+    }
+    if (status) {
+      conditions.push(`status = $${idx++}`)
+      params.push(status)
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+
+    // Count (separate query — Postgres planner handles this well on 23k rows)
+    const countRes = await client.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM leads ${where}`,
+      params,
+    )
+    const total = parseInt(countRes.rows[0]?.count ?? '0', 10)
+
+    // Rows — SELECT only, no writes
+    const dataRes = await client.query<LeadRow>(
+      `SELECT id, name, phone, phone_adjusted, company, source, status, ativo, dealid
+         FROM leads ${where}
+        ORDER BY created_at DESC
+        LIMIT $${idx} OFFSET $${idx + 1}`,
+      [...params, limit, offset],
+    )
+
+    const items = dataRes.rows.map(r => ({
+      id:            r.id,
+      name:          r.name,
+      phone:         r.phone_adjusted ?? r.phone,
+      company:       r.company,
+      source:        r.source,
+      status:        r.status,
+      ativo:         r.ativo,
+    }))
+
+    return NextResponse.json({ items, page, limit, total })
+  } catch (err) {
+    console.error('[sdr leads GET]', err)
+    return NextResponse.json(
+      { error: 'db_error', message: (err as Error).message },
+      { status: 502 },
+    )
+  } finally {
+    await client.end().catch(() => {})
+  }
+}

--- a/app/api/sdr/settings/route.ts
+++ b/app/api/sdr/settings/route.ts
@@ -105,8 +105,8 @@ export async function GET() {
   try { parsed = JSON.parse(row.settings) } catch {}
 
   // Omit secrets from GET response; URLs are returned for UI display
-  const { n8nWebhookSecret: _omitWS, n8nDispatchSecret: _omitDS, ...settingsForClient } = parsed
-  void _omitWS; void _omitDS
+  const { n8nWebhookSecret: _omitWS, n8nDispatchSecret: _omitDS, n8nEnrollSecret: _omitES, ...settingsForClient } = parsed
+  void _omitWS; void _omitDS; void _omitES
 
   return NextResponse.json({ configured: true, status: row.status, version: row.version, settings: settingsForClient })
 }
@@ -158,6 +158,18 @@ export async function PUT(request: Request) {
     }
   }
 
+  // Validate enrollment URL if provided (same anti-SSRF rules)
+  if (rawSettings.n8nEnrollUrl !== undefined && rawSettings.n8nEnrollUrl !== '') {
+    try {
+      validateWebhookUrl(rawSettings.n8nEnrollUrl)
+    } catch (err) {
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : 'n8nEnrollUrl inválida' },
+        { status: 400 },
+      )
+    }
+  }
+
   // Validate remetente E.164 if provided and non-empty
   if (rawSettings.remetente !== undefined && rawSettings.remetente !== '') {
     if (typeof rawSettings.remetente !== 'string' || !E164_RE.test(rawSettings.remetente)) {
@@ -179,7 +191,7 @@ export async function PUT(request: Request) {
 
   // Preserve stored secrets when the incoming PUT omits or clears them.
   // (GET strips secrets, so the UI cannot re-send them on subsequent saves.)
-  if (existing && (!rawSettings.n8nWebhookSecret || !rawSettings.n8nDispatchSecret)) {
+  if (existing && (!rawSettings.n8nWebhookSecret || !rawSettings.n8nDispatchSecret || !rawSettings.n8nEnrollSecret)) {
     try {
       const stored = JSON.parse(existing.settings) as Record<string, unknown>
       if (!rawSettings.n8nWebhookSecret && typeof stored.n8nWebhookSecret === 'string' && stored.n8nWebhookSecret) {
@@ -187,6 +199,9 @@ export async function PUT(request: Request) {
       }
       if (!rawSettings.n8nDispatchSecret && typeof stored.n8nDispatchSecret === 'string' && stored.n8nDispatchSecret) {
         rawSettings.n8nDispatchSecret = stored.n8nDispatchSecret
+      }
+      if (!rawSettings.n8nEnrollSecret && typeof stored.n8nEnrollSecret === 'string' && stored.n8nEnrollSecret) {
+        rawSettings.n8nEnrollSecret = stored.n8nEnrollSecret
       }
     } catch { /* corrupt stored JSON — skip merge */ }
   }
@@ -233,9 +248,11 @@ export async function PUT(request: Request) {
       n8nWebhookSecret: _s,
       n8nDispatchUrl: _du,
       n8nDispatchSecret: _ds,
+      n8nEnrollUrl: _eu,
+      n8nEnrollSecret: _es,
       ...settingsPayload
     } = rawSettings
-    void _u; void _s; void _du; void _ds
+    void _u; void _s; void _du; void _ds; void _eu; void _es
     const payload = {
       tenantId,
       status,

--- a/lib/modules.ts
+++ b/lib/modules.ts
@@ -30,6 +30,7 @@ export const ALL_MODULE_KEYS: string[] = MODULES.map(m => m.key)
 const PATH_MODULE_OVERRIDES: Record<string, string> = {
   '/sdr-ia/contatos':  'integration.ycloud-whatsapp',
   '/sdr-ia/conversas': 'integration.ycloud-whatsapp',
+  '/sdr-ia/leads':     'sdr.parametros',
 }
 
 export function moduleKeyForPath(pathname: string): string | null {


### PR DESCRIPTION
Página Leads pra selecionar leads e adicioná-los à campanha:
- /api/sdr/leads: GET dos leads do Supabase (read-only, só SELECT) via a
  connection string da fonte SDR; busca/filtros + paginação; session + entitlement.
- /api/sdr/enroll: POST dos leadIds num webhook de enrollment do n8n (cria as
  lead_actions); cap de 100, valida UUID, Bearer opcional, nunca derruba.
- Parâmetros: campo "URL de enrollment (n8n)" (+ secret), com strip do payload
  de write-back e preservação de secret igual aos outros.
- Página /sdr-ia/leads (tab gateada por PATH_MODULE_OVERRIDES) + Adicionar à campanha.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
