### PR TITLE
fix: ampliar layout da página de Parâmetros para full width

### DIFF
--- a/app/(app)/sdr-ia/parametros/page.tsx
+++ b/app/(app)/sdr-ia/parametros/page.tsx
@@ -268,7 +268,7 @@ export default function ParametrosPage() {
   const hasWebhook   = !!n8nWebhookUrl
 
   return (
-    <div style={{ maxWidth: 720 }}>
+    <div>
 
       {/* ── Aviso write-back ────────────────────────────────────── */}
       <div style={{
@@ -284,6 +284,9 @@ export default function ParametrosPage() {
           }
         </div>
       </div>
+
+      {/* ── Status + Tom: 2 colunas no desktop, 1 no mobile ───────── */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(460px, 100%), 1fr))', gap: 16, alignItems: 'start' }}>
 
       {/* ── Status ──────────────────────────────────────────────── */}
       <SectionCard title="Status da campanha">
@@ -356,6 +359,10 @@ export default function ParametrosPage() {
           onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
         />
       </SectionCard>
+      </div>{/* /Status+Tom grid */}
+
+      {/* ── Sequência + Cadência: 2 colunas no desktop ──────────── */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(460px, 100%), 1fr))', gap: 16, alignItems: 'start' }}>
 
       {/* ── Sequência de disparo ────────────────────────────────── */}
       <SectionCard title="Sequência de disparo">
@@ -518,6 +525,7 @@ export default function ParametrosPage() {
           })}
         </div>
       </SectionCard>
+      </div>{/* /Sequência+Cadência grid */}
 
       {/* ── Templates ───────────────────────────────────────────── */}
       <SectionCard title="Templates de mensagem">


### PR DESCRIPTION
## Summary
- Remove `maxWidth: 720` que deixava os cards numa coluna estreita à esquerda da página de Parâmetros
- Status + Tom e objetivo passam a ficar lado a lado em 2 colunas (desktop)
- Sequência de disparo + Cadência e horário também em 2 colunas (desktop)
- Demais cards (Templates, Integração n8n, Teste, Fonte de dados, Salvar) permanecem full width
- Responsivo via `auto-fit minmax(min(460px, 100%), 1fr)` — 1 coluna no mobile sem JS ou media queries

## Test plan
- [ ] Verificar página de Parâmetros no desktop: cards devem ocupar largura disponível
- [ ] Verificar pares Status/Tom e Sequência/Cadência em 2 colunas
- [ ] Verificar em mobile: todos os cards em 1 coluna
- [ ] Confirmar que outras páginas do SDR (Dashboard, Leads, Contatos, Conversas) não foram afetadas
- [ ] `npx tsc --noEmit` passa limpo ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)