### PR TITLE
feat: troca ícones custom por lucide-react nas integrações

### DIFF
--- a/app/(app)/settings/integrations/kommo/page.tsx
+++ b/app/(app)/settings/integrations/kommo/page.tsx
@@ -2,7 +2,8 @@
 import Link from 'next/link'
 import { useState, useEffect, useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { RefreshCw, TriangleAlert, Lock } from 'lucide-react'
+import { RefreshCw, TriangleAlert, Lock, Clock, Rocket, Trash2, Users, CheckCircle2, XCircle, Check } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
 
 type Step = 1 | 2 | 3
 type IntegrationStatus = 'disconnected' | 'configured' | 'connected' | 'expired'
@@ -141,14 +142,14 @@ function ConfirmModal({ pipelineName, onConfirm, onCancel }: {
 
 // ─── SyncProgressCard ──────────────────────────────────────────────────────────
 
-const STAGE_META: Record<SyncStage, { icon: string; label: string; color: string }> = {
-  idle:     { icon: '⏳', label: 'Aguardando...', color: 'var(--gray2)' },
-  starting: { icon: '🚀', label: 'Iniciando sincronização...', color: 'var(--primary-text)' },
-  cleaning: { icon: '🗑️', label: 'Limpando dados anteriores...', color: '#d97706' },
-  pipeline: { icon: '🔄', label: 'Sincronizando funil e etapas...', color: 'var(--primary-text)' },
-  leads:    { icon: '👥', label: 'Importando leads...', color: 'var(--primary-text)' },
-  done:     { icon: '✅', label: 'Concluído!', color: 'var(--green)' },
-  error:    { icon: '❌', label: 'Erro na sincronização', color: 'var(--red)' },
+const STAGE_META: Record<SyncStage, { Icon: LucideIcon; label: string; color: string; spin?: boolean }> = {
+  idle:     { Icon: Clock,        label: 'Aguardando...',                    color: 'var(--gray2)' },
+  starting: { Icon: Rocket,       label: 'Iniciando sincronização...',       color: 'var(--primary-text)' },
+  cleaning: { Icon: Trash2,       label: 'Limpando dados anteriores...',     color: '#d97706' },
+  pipeline: { Icon: RefreshCw,    label: 'Sincronizando funil e etapas...', color: 'var(--primary-text)', spin: true },
+  leads:    { Icon: Users,        label: 'Importando leads...',              color: 'var(--primary-text)' },
+  done:     { Icon: CheckCircle2, label: 'Concluído!',                       color: 'var(--green)' },
+  error:    { Icon: XCircle,      label: 'Erro na sincronização',            color: 'var(--red)' },
 }
 
 function SyncProgressCard({ progress }: { progress: SyncProgress }) {
@@ -170,7 +171,7 @@ function SyncProgressCard({ progress }: { progress: SyncProgress }) {
     }}>
       {/* Stage row */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
-        <span style={{ fontSize: 18, lineHeight: 1 }}>{meta.icon}</span>
+        <meta.Icon size={18} color={meta.color} className={meta.spin ? 'animate-spin' : undefined} />
         <div style={{ flex: 1 }}>
           <div style={{ fontSize: 13, fontWeight: 700, color: meta.color }}>{meta.label}</div>
           {progress.message && progress.stage !== 'done' && progress.stage !== 'error' && (
@@ -701,7 +702,7 @@ export default function IntegrationPage() {
               {/* Notice when pipeline not saved or has unsaved change */}
               {(hasUnsavedChange || (!hasSavedPipeline && selectedPipelineId)) && !loadingPipelines && (
                 <div style={{ marginTop: 8, fontSize: 11, color: '#d97706', fontWeight: 600, display: 'flex', alignItems: 'center', gap: 4 }}>
-                  ⚠️ {hasUnsavedChange ? 'Funil alterado — salve antes de sincronizar' : 'Salve a seleção do funil antes de sincronizar'}
+                  <TriangleAlert size={11} color="#d97706" /> {hasUnsavedChange ? 'Funil alterado — salve antes de sincronizar' : 'Salve a seleção do funil antes de sincronizar'}
                 </div>
               )}
 
@@ -748,9 +749,7 @@ export default function IntegrationPage() {
               {/* Read-only notice */}
               {!syncing && (
                 <div style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 11, color: 'var(--gray2)', fontWeight: 500 }}>
-                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="var(--green)" strokeWidth="1.5">
-                    <rect x="3" y="7" width="10" height="7" rx="1.5"/><path d="M5 7V5a3 3 0 0 1 6 0v2"/>
-                  </svg>
+                  <Lock size={12} color="var(--green)" />
                   Somente leitura — nenhum dado alterado no Kommo
                 </div>
               )}
@@ -772,7 +771,7 @@ export default function IntegrationPage() {
             ].map(([t, d]) => (
               <div key={t} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, marginBottom: 12 }}>
                 <div style={{ width: 20, height: 20, borderRadius: 100, background: 'rgba(30,138,62,0.1)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, marginTop: 1 }}>
-                  <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="var(--green)" strokeWidth="2"><path d="M2 6l3 3 5-5"/></svg>
+                  <Check size={10} color="var(--green)" />
                 </div>
                 <div>
                   <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--black)' }}>{t}</div>

--- a/app/(app)/settings/integrations/sdr-source/page.tsx
+++ b/app/(app)/settings/integrations/sdr-source/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import Link from 'next/link'
 import { useState, useEffect, useCallback } from 'react'
+import { Loader2, CheckCircle2, XCircle, Eye, EyeOff } from 'lucide-react'
 
 interface SourceData {
   configured: boolean
@@ -23,35 +24,6 @@ function timeAgo(ms: number): string {
   return `há ${days} dia${days > 1 ? 's' : ''}`
 }
 
-function EyeIcon({ open }: { open: boolean }) {
-  if (open) {
-    return (
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-        <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
-        <line x1="1" y1="1" x2="23" y2="23" />
-      </svg>
-    )
-  }
-  return (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-      <circle cx="12" cy="12" r="3" />
-    </svg>
-  )
-}
-
-function SpinIcon() {
-  return (
-    <svg
-      width="14" height="14" viewBox="0 0 16 16" fill="none"
-      stroke="currentColor" strokeWidth="2"
-      style={{ animation: 'spin 1s linear infinite' }}
-    >
-      <path d="M1 4v5h5M15 12v-5h-5" />
-      <path d="M13.4 7A6 6 0 1 0 12 12.3" />
-    </svg>
-  )
-}
 
 function SyncStatus({ data }: { data: SourceData }) {
   const s = data.lastSyncStatus
@@ -68,7 +40,7 @@ function SyncStatus({ data }: { data: SourceData }) {
   if (s === 'running') {
     return (
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, fontWeight: 600, color: 'var(--primary-text)' }}>
-        <SpinIcon />
+        <Loader2 size={14} className="animate-spin" />
         Sincronizando dados…
       </div>
     )
@@ -77,9 +49,7 @@ function SyncStatus({ data }: { data: SourceData }) {
   if (s === 'success') {
     return (
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, fontWeight: 600, color: 'var(--green)' }}>
-        <svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="var(--green)" strokeWidth="2">
-          <path d="M2 6l3 3 5-5" />
-        </svg>
+        <CheckCircle2 size={14} color="var(--green)" />
         Última sincronização {data.lastSyncAt ? timeAgo(data.lastSyncAt) : '—'}
       </div>
     )
@@ -87,9 +57,7 @@ function SyncStatus({ data }: { data: SourceData }) {
 
   return (
     <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, fontSize: 13, fontWeight: 600, color: 'var(--red)' }}>
-      <svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="var(--red)" strokeWidth="2" style={{ marginTop: 1, flexShrink: 0 }}>
-        <path d="M2 2l8 8M10 2L2 10" />
-      </svg>
+      <XCircle size={14} color="var(--red)" style={{ marginTop: 1, flexShrink: 0 }} />
       <span>Erro na sincronização{data.lastSyncError ? `: ${data.lastSyncError}` : ''}</span>
     </div>
   )
@@ -232,9 +200,7 @@ export default function SdrSourcePage() {
               fontSize: 13, fontWeight: 600, color: '#145c2a',
               display: 'flex', alignItems: 'center', gap: 8,
             }}>
-              <svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="var(--green)" strokeWidth="2">
-                <path d="M2 6l3 3 5-5" />
-              </svg>
+              <CheckCircle2 size={14} color="var(--green)" />
               Fonte salva — backfill iniciado em segundo plano
             </div>
           )}
@@ -308,7 +274,7 @@ export default function SdrSourcePage() {
                 border: 'none', cursor: 'pointer', color: 'var(--gray2)', padding: 2,
               }}
             >
-              <EyeIcon open={showConn} />
+              {showConn ? <EyeOff size={16} /> : <Eye size={16} />}
             </button>
           </div>
           <div style={{ fontSize: 12, color: 'var(--gray2)', fontWeight: 500 }}>
@@ -328,16 +294,12 @@ export default function SdrSourcePage() {
           }}>
             {testResult.valid ? (
               <>
-                <svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="var(--green)" strokeWidth="2">
-                  <path d="M2 6l3 3 5-5" />
-                </svg>
+                <CheckCircle2 size={14} color="var(--green)" />
                 Conexão bem-sucedida — banco acessível
               </>
             ) : (
               <>
-                <svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="#b02619" strokeWidth="2">
-                  <path d="M2 2l8 8M10 2L2 10" />
-                </svg>
+                <XCircle size={14} color="#b02619" />
                 {testResult.error ?? 'Falha na conexão'}
               </>
             )}
@@ -352,9 +314,7 @@ export default function SdrSourcePage() {
             background: 'rgba(217,48,37,0.06)', border: '1px solid rgba(217,48,37,0.2)',
             display: 'flex', alignItems: 'center', gap: 8,
           }}>
-            <svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="#b02619" strokeWidth="2">
-              <path d="M2 2l8 8M10 2L2 10" />
-            </svg>
+            <XCircle size={14} color="#b02619" />
             {saveError}
           </div>
         )}
@@ -373,7 +333,7 @@ export default function SdrSourcePage() {
               display: 'flex', alignItems: 'center', gap: 7,
             }}
           >
-            {testing && <SpinIcon />}
+            {testing && <Loader2 size={14} className="animate-spin" />}
             {testing ? 'Testando…' : 'Testar conexão'}
           </button>
 
@@ -389,18 +349,12 @@ export default function SdrSourcePage() {
               display: 'flex', alignItems: 'center', gap: 7,
             }}
           >
-            {saving && <SpinIcon />}
+            {saving && <Loader2 size={14} className="animate-spin" />}
             {saving ? 'Salvando…' : 'Salvar e conectar'}
           </button>
         </div>
       </div>
 
-      <style>{`
-        @keyframes spin {
-          from { transform: rotate(0deg) }
-          to   { transform: rotate(360deg) }
-        }
-      `}</style>
     </div>
   )
 }

--- a/app/(app)/settings/integrations/ycloud/page.tsx
+++ b/app/(app)/settings/integrations/ycloud/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import Link from 'next/link'
 import { useState, useEffect, useCallback } from 'react'
+import { Loader2, CheckCircle2, XCircle, Copy, Eye, EyeOff } from 'lucide-react'
 
 interface SourceData {
   configured: boolean
@@ -12,60 +13,6 @@ interface SourceData {
   webhookUrl?: string | null
 }
 
-function EyeIcon({ open }: { open: boolean }) {
-  if (open) {
-    return (
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-        <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
-        <line x1="1" y1="1" x2="23" y2="23" />
-      </svg>
-    )
-  }
-  return (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-      <circle cx="12" cy="12" r="3" />
-    </svg>
-  )
-}
-
-function SpinIcon() {
-  return (
-    <svg
-      width="14" height="14" viewBox="0 0 16 16" fill="none"
-      stroke="currentColor" strokeWidth="2"
-      style={{ animation: 'spin 1s linear infinite' }}
-    >
-      <path d="M1 4v5h5M15 12v-5h-5" />
-      <path d="M13.4 7A6 6 0 1 0 12 12.3" />
-    </svg>
-  )
-}
-
-function CopyIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-      <rect x="9" y="9" width="13" height="13" rx="2" />
-      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-    </svg>
-  )
-}
-
-function CheckSmIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="var(--green)" strokeWidth="2">
-      <path d="M2 6l3 3 5-5" />
-    </svg>
-  )
-}
-
-function XSmIcon({ color = '#b02619' }: { color?: string }) {
-  return (
-    <svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke={color} strokeWidth="2">
-      <path d="M2 2l8 8M10 2L2 10" />
-    </svg>
-  )
-}
 
 const inputStyle: React.CSSProperties = {
   width: '100%',
@@ -182,7 +129,7 @@ function SecretField({
             border: 'none', cursor: 'pointer', color: 'var(--gray2)', padding: 2,
           }}
         >
-          <EyeIcon open={show} />
+          {show ? <EyeOff size={16} /> : <Eye size={16} />}
         </button>
       </div>
     </div>
@@ -366,7 +313,7 @@ export default function YCloudPage() {
             display: 'flex', alignItems: 'center', gap: 8,
             fontSize: 13, fontWeight: 700, color: '#145c2a', marginBottom: 14,
           }}>
-            <CheckSmIcon />
+            <CheckCircle2 size={14} color="var(--green)" />
             Integração salva com sucesso!
           </div>
 
@@ -458,9 +405,9 @@ export default function YCloudPage() {
             color: testResult.valid ? '#145c2a' : '#b02619',
           }}>
             {testResult.valid ? (
-              <><CheckSmIcon />API Key válida — conexão bem-sucedida</>
+              <><CheckCircle2 size={14} color="var(--green)" />API Key válida — conexão bem-sucedida</>
             ) : (
-              <><XSmIcon />{testResult.error ?? 'Falha na conexão'}</>
+              <><XCircle size={14} color="#b02619" />{testResult.error ?? 'Falha na conexão'}</>
             )}
           </div>
         )}
@@ -473,7 +420,7 @@ export default function YCloudPage() {
             background: 'rgba(217,48,37,0.06)', border: '1px solid rgba(217,48,37,0.2)',
             display: 'flex', alignItems: 'center', gap: 8,
           }}>
-            <XSmIcon />{saveError}
+            <XCircle size={14} color="#b02619" />{saveError}
           </div>
         )}
 
@@ -491,7 +438,7 @@ export default function YCloudPage() {
               display: 'flex', alignItems: 'center', gap: 7,
             }}
           >
-            {testing && <SpinIcon />}
+            {testing && <Loader2 size={14} className="animate-spin" />}
             {testing ? 'Testando…' : 'Testar conexão'}
           </button>
 
@@ -507,18 +454,12 @@ export default function YCloudPage() {
               display: 'flex', alignItems: 'center', gap: 7,
             }}
           >
-            {saving && <SpinIcon />}
+            {saving && <Loader2 size={14} className="animate-spin" />}
             {saving ? 'Salvando…' : 'Salvar e conectar'}
           </button>
         </div>
       </div>
 
-      <style>{`
-        @keyframes spin {
-          from { transform: rotate(0deg) }
-          to   { transform: rotate(360deg) }
-        }
-      `}</style>
     </div>
   )
 }
@@ -554,7 +495,7 @@ function WebhookUrlBox({ url, copied, onCopy }: { url: string; copied: boolean; 
           transition: 'all .15s',
         }}
       >
-        {copied ? <CheckSmIcon /> : <CopyIcon />}
+        {copied ? <CheckCircle2 size={14} color="var(--green)" /> : <Copy size={14} />}
         {copied ? 'Copiado!' : 'Copiar'}
       </button>
     </div>


### PR DESCRIPTION
Substitui emojis, SVGs inline e o spinner custom (SpinIcon) por ícones do
lucide-react nas páginas de integração, com giro nos de carregamento.

- sdr-source: SpinIcon/Eye/SVGs → Loader2 (animate-spin), Eye/EyeOff, CheckCircle2, XCircle.
- ycloud: SpinIcon/Eye/Copy/Check/X → Loader2, Eye/EyeOff, Copy, CheckCircle2, XCircle.
- kommo: STAGE_META vira Icon: LucideIcon (Clock/Rocket/Trash2/RefreshCw/Users/
  CheckCircle2/XCircle) + Lock/Check/TriangleAlert; pipeline gira via spin:true.
- Remove @keyframes spin de sdr-source/ycloud (usa animate-spin do Tailwind).

Só visual — nenhuma lógica alterada.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
