### PR TITLE
feat: importação de leads via Excel com dedup e envio ao n8n

### DIFF
--- a/app/(app)/sdr-ia/leads/page.tsx
+++ b/app/(app)/sdr-ia/leads/page.tsx
@@ -21,18 +21,36 @@ interface ApiResponse {
   total: number
 }
 
+interface ImportResult {
+  ok:         boolean
+  totalLinhas?: number
+  importados?:  number
+  ignorados?:   { total: number; amostra: Array<{ linha: number; motivo: string }> }
+  duplicados?:  { total: number; amostra: Array<{ linha: number; telefone: string }> }
+  n8nStatus?:   number
+  error?:       string
+}
+
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const LIMIT = 50
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+function friendlyImportError(code: string): string {
+  if (code === 'import_url_nao_configurada')
+    return 'URL de importação n8n não configurada — acesse Parâmetros > Integrações n8n.'
+  if (code === 'fonte_sdr_nao_configurada')
+    return 'Fonte de dados SDR não configurada — acesse Configurações > Integrações.'
+  return code
+}
+
 function StatusBadge({ value }: { value: string | null }) {
   if (!value) return <span style={{ color: 'var(--gray3)', fontSize: 11 }}>—</span>
   const colors: Record<string, { bg: string; color: string }> = {
-    ativo:     { bg: 'rgba(34,197,94,0.10)',  color: '#15803d' },
-    inativo:   { bg: 'rgba(239,68,68,0.08)',  color: 'var(--red)' },
-    qualificado: { bg: 'rgba(37,99,235,0.10)', color: '#1d4ed8' },
+    ativo:       { bg: 'rgba(34,197,94,0.10)',  color: '#15803d' },
+    inativo:     { bg: 'rgba(239,68,68,0.08)',  color: 'var(--red)' },
+    qualificado: { bg: 'rgba(37,99,235,0.10)',  color: '#1d4ed8' },
   }
   const style = colors[value.toLowerCase()] ?? { bg: 'rgba(0,0,0,0.05)', color: 'var(--gray)' }
   return (
@@ -49,17 +67,21 @@ function StatusBadge({ value }: { value: string | null }) {
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function LeadsPage() {
-  const [data,      setData]      = useState<ApiResponse | null>(null)
-  const [loading,   setLoading]   = useState(true)
-  const [error,     setError]     = useState<string | null>(null)
-  const [page,      setPage]      = useState(1)
-  const [q,         setQ]         = useState('')
-  const [debQ,      setDebQ]      = useState('')
-  const [selected,  setSelected]  = useState<Set<string>>(new Set())
-  const [enrolling, setEnrolling] = useState(false)
+  const [data,         setData]         = useState<ApiResponse | null>(null)
+  const [loading,      setLoading]      = useState(true)
+  const [error,        setError]        = useState<string | null>(null)
+  const [page,         setPage]         = useState(1)
+  const [q,            setQ]            = useState('')
+  const [debQ,         setDebQ]         = useState('')
+  const [selected,     setSelected]     = useState<Set<string>>(new Set())
+  const [enrolling,    setEnrolling]    = useState(false)
   const [enrollResult, setEnrollResult] = useState<{ ok: boolean; enrolled?: number; error?: string } | null>(null)
+  const [importing,    setImporting]    = useState(false)
+  const [importResult, setImportResult] = useState<ImportResult | null>(null)
+  const [fetchSeq,     setFetchSeq]     = useState(0)
 
-  const masterRef = useRef<HTMLInputElement>(null)
+  const masterRef   = useRef<HTMLInputElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   // Debounce search
   useEffect(() => {
@@ -88,12 +110,12 @@ export default function LeadsPage() {
       .catch((e: unknown) => { if (!cancelled) { setError(String(e)); setLoading(false) } })
 
     return () => { cancelled = true }
-  }, [page, debQ])
+  }, [page, debQ, fetchSeq])
 
   // Keep master checkbox indeterminate state in sync
-  const pageIds  = data?.items.map(i => i.id) ?? []
-  const selCount = pageIds.filter(id => selected.has(id)).length
-  const allOnPage = pageIds.length > 0 && selCount === pageIds.length
+  const pageIds    = data?.items.map(i => i.id) ?? []
+  const selCount   = pageIds.filter(id => selected.has(id)).length
+  const allOnPage  = pageIds.length > 0 && selCount === pageIds.length
   const someOnPage = selCount > 0 && selCount < pageIds.length
 
   useEffect(() => {
@@ -142,10 +164,43 @@ export default function LeadsPage() {
     }
   }
 
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    e.target.value = ''  // reset so the same file can be re-selected
+    if (!file) return
+
+    setImporting(true)
+    setImportResult(null)
+    try {
+      const fd = new FormData()
+      fd.append('file', file)
+      const res = await fetch('/api/sdr/leads/import', { method: 'POST', body: fd })
+      const json = await res.json() as ImportResult & { error?: string }
+      if (!res.ok) {
+        setImportResult({ ok: false, error: json.error ?? `HTTP ${res.status}` })
+      } else {
+        setImportResult(json)
+        // Reload list — n8n inserts asynchronously, so new leads may take a moment to appear
+        setPage(1)
+        setFetchSeq(s => s + 1)
+      }
+    } catch (e) {
+      setImportResult({ ok: false, error: (e as Error).message })
+    } finally {
+      setImporting(false)
+    }
+  }
+
   const total      = data?.total ?? 0
   const totalPages = Math.max(1, Math.ceil(total / LIMIT))
   const hasPrev    = page > 1
   const hasNext    = page < totalPages
+
+  // n8nFalhou: leads were sent but the webhook returned a non-2xx status.
+  // importados = 0 (nothing sent) is NOT a failure — n8nStatus stays 0 in that case.
+  const n8nFalhou = (importResult?.importados ?? 0) > 0
+    && typeof importResult?.n8nStatus === 'number'
+    && (importResult.n8nStatus < 200 || importResult.n8nStatus >= 300)
 
   return (
     <div>
@@ -164,28 +219,177 @@ export default function LeadsPage() {
           </div>
         </div>
 
-        {/* Search */}
-        <div style={{ position: 'relative' }}>
-          <Search size={14} style={{
-            position: 'absolute', left: 12, top: '50%', transform: 'translateY(-50%)',
-            color: 'var(--gray2)', pointerEvents: 'none',
-          }} />
-          <input
-            value={q}
-            onChange={e => setQ(e.target.value)}
-            placeholder="Nome, telefone ou empresa..."
+        {/* Actions + Search */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' as const }}>
+          {/* Download template */}
+          <a
+            href="/api/sdr/leads/template"
+            download="modelo-leads.xlsx"
             style={{
-              paddingLeft: 34, paddingRight: 14, paddingTop: 9, paddingBottom: 9,
-              fontSize: 13, fontFamily: 'inherit', fontWeight: 500,
-              border: '1px solid var(--gray3)', borderRadius: 99,
-              background: 'var(--white)', color: 'var(--black)',
-              outline: 'none', transition: 'border-color .15s', minWidth: 240,
+              display: 'inline-flex', alignItems: 'center',
+              padding: '8px 16px', borderRadius: 99,
+              fontSize: 12, fontWeight: 700, textDecoration: 'none',
+              border: '1px solid var(--gray3)',
+              background: 'transparent', color: 'var(--gray)',
+              cursor: 'pointer', transition: 'all .15s', whiteSpace: 'nowrap' as const,
             }}
-            onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
-            onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+          >
+            Baixar modelo
+          </a>
+
+          {/* Import Excel */}
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            disabled={importing}
+            style={{
+              padding: '8px 16px', borderRadius: 99, fontFamily: 'inherit',
+              fontSize: 12, fontWeight: 700, cursor: importing ? 'not-allowed' : 'pointer',
+              border: `1.5px solid ${importing ? 'var(--gray3)' : 'var(--primary)'}`,
+              background: 'transparent',
+              color: importing ? 'var(--gray2)' : 'var(--primary-text)',
+              transition: 'all .15s', whiteSpace: 'nowrap' as const,
+              opacity: importing ? 0.65 : 1,
+            }}
+          >
+            {importing ? 'Importando...' : 'Importar Excel'}
+          </button>
+
+          {/* Hidden file input */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".xlsx,.xls"
+            style={{ display: 'none' }}
+            onChange={handleFileChange}
           />
+
+          {/* Search */}
+          <div style={{ position: 'relative' }}>
+            <Search size={14} style={{
+              position: 'absolute', left: 12, top: '50%', transform: 'translateY(-50%)',
+              color: 'var(--gray2)', pointerEvents: 'none',
+            }} />
+            <input
+              value={q}
+              onChange={e => setQ(e.target.value)}
+              placeholder="Nome, telefone ou empresa..."
+              style={{
+                paddingLeft: 34, paddingRight: 14, paddingTop: 9, paddingBottom: 9,
+                fontSize: 13, fontFamily: 'inherit', fontWeight: 500,
+                border: '1px solid var(--gray3)', borderRadius: 99,
+                background: 'var(--white)', color: 'var(--black)',
+                outline: 'none', transition: 'border-color .15s', minWidth: 240,
+              }}
+              onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+              onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+            />
+          </div>
         </div>
       </div>
+
+      {/* ── Import result panel ─────────────────────────────────────── */}
+      {importResult && (
+        <div style={{
+          marginBottom: 16,
+          background: !importResult.ok
+            ? 'rgba(239,68,68,0.06)'
+            : n8nFalhou
+              ? 'rgba(245,158,11,0.08)'
+              : 'rgba(34,197,94,0.06)',
+          border: `1px solid ${
+            !importResult.ok
+              ? 'rgba(239,68,68,0.25)'
+              : n8nFalhou
+                ? 'rgba(245,158,11,0.35)'
+                : 'rgba(34,197,94,0.25)'
+          }`,
+          borderRadius: 12, padding: '14px 18px',
+        }}>
+          {importResult.ok ? (
+            <>
+              <div style={{ fontSize: 13, fontWeight: 700, marginBottom: 8,
+                color: n8nFalhou ? '#b45309' : 'var(--green)',
+              }}>
+                {n8nFalhou
+                  ? `⚠ ${importResult.importados} lead${importResult.importados !== 1 ? 's' : ''} enviados, mas o n8n retornou HTTP ${importResult.n8nStatus} — podem não ter sido importados. Verifique o fluxo de importação no n8n.`
+                  : `✓ ${importResult.importados} lead${importResult.importados !== 1 ? 's' : ''} enviados ao n8n para importação`
+                }
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--gray)', fontWeight: 500, marginBottom: 6 }}>
+                {importResult.importados} importados
+                {' · '}{importResult.ignorados?.total ?? 0} ignorados
+                {' · '}{importResult.duplicados?.total ?? 0} duplicados
+                {' — '}{importResult.totalLinhas} linha{importResult.totalLinhas !== 1 ? 's' : ''} no arquivo
+              </div>
+
+              {(importResult.ignorados?.total ?? 0) > 0 && (
+                <details style={{ marginTop: 8 }}>
+                  <summary style={{
+                    fontSize: 12, color: 'var(--gray2)', cursor: 'pointer',
+                    fontWeight: 600, userSelect: 'none' as const,
+                  }}>
+                    Ignorados ({importResult.ignorados!.total})
+                  </summary>
+                  <div style={{ marginTop: 6, display: 'flex', flexDirection: 'column', gap: 3 }}>
+                    {importResult.ignorados!.amostra.map((it, i) => (
+                      <div key={i} style={{ fontSize: 11, color: 'var(--gray)', fontFamily: 'monospace' }}>
+                        Linha {it.linha}: {it.motivo}
+                      </div>
+                    ))}
+                    {importResult.ignorados!.total > importResult.ignorados!.amostra.length && (
+                      <div style={{ fontSize: 11, color: 'var(--gray2)', fontStyle: 'italic' }}>
+                        … e mais {importResult.ignorados!.total - importResult.ignorados!.amostra.length}
+                      </div>
+                    )}
+                  </div>
+                </details>
+              )}
+
+              {(importResult.duplicados?.total ?? 0) > 0 && (
+                <details style={{ marginTop: 6 }}>
+                  <summary style={{
+                    fontSize: 12, color: 'var(--gray2)', cursor: 'pointer',
+                    fontWeight: 600, userSelect: 'none' as const,
+                  }}>
+                    Duplicados ({importResult.duplicados!.total})
+                  </summary>
+                  <div style={{ marginTop: 6, display: 'flex', flexDirection: 'column', gap: 3 }}>
+                    {importResult.duplicados!.amostra.map((it, i) => (
+                      <div key={i} style={{ fontSize: 11, color: 'var(--gray)', fontFamily: 'monospace' }}>
+                        Linha {it.linha}: {it.telefone}
+                      </div>
+                    ))}
+                    {importResult.duplicados!.total > importResult.duplicados!.amostra.length && (
+                      <div style={{ fontSize: 11, color: 'var(--gray2)', fontStyle: 'italic' }}>
+                        … e mais {importResult.duplicados!.total - importResult.duplicados!.amostra.length}
+                      </div>
+                    )}
+                  </div>
+                </details>
+              )}
+
+              <div style={{ fontSize: 11, color: 'var(--gray2)', marginTop: 10, lineHeight: 1.5 }}>
+                O n8n processa de forma assíncrona — os leads podem levar alguns instantes para aparecer na lista.
+                {' '}
+                <button
+                  onClick={() => setFetchSeq(s => s + 1)}
+                  style={{
+                    background: 'none', border: 'none', padding: 0,
+                    fontSize: 11, fontWeight: 700, color: 'var(--primary-text)',
+                    cursor: 'pointer', textDecoration: 'underline',
+                  }}
+                >
+                  Atualizar lista
+                </button>
+              </div>
+            </>
+          ) : (
+            <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--red)' }}>
+              ✗ {friendlyImportError(importResult.error ?? 'Erro desconhecido')}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* ── Enroll bar ─────────────────────────────────────────────── */}
       <div style={{
@@ -296,7 +500,7 @@ export default function LeadsPage() {
                 </tr>
               ) : (data?.items ?? []).map((lead, i) => {
                 const checked = selected.has(lead.id)
-                const isLast = i === (data?.items.length ?? 0) - 1
+                const isLast  = i === (data?.items.length ?? 0) - 1
                 return (
                   <tr
                     key={lead.id}

--- a/app/(app)/sdr-ia/parametros/page.tsx
+++ b/app/(app)/sdr-ia/parametros/page.tsx
@@ -24,6 +24,7 @@ interface Settings {
   n8nWebhookUrl?:   string
   n8nDispatchUrl?:  string
   n8nEnrollUrl?:    string
+  n8nImportUrl?:    string
 }
 
 interface ApiData {
@@ -171,6 +172,9 @@ export default function ParametrosPage() {
   const [n8nEnrollUrl,       setN8nEnrollUrl]       = useState('')
   const [n8nEnrollSecret,    setN8nEnrollSecret]    = useState('')
   const [showEnrollSecret,   setShowEnrollSecret]   = useState(false)
+  const [n8nImportUrl,       setN8nImportUrl]       = useState('')
+  const [n8nImportSecret,    setN8nImportSecret]    = useState('')
+  const [showImportSecret,   setShowImportSecret]   = useState(false)
   const [remetenteError,     setRemetenteError]     = useState<string | null>(null)
   const [loading,            setLoading]            = useState(true)
   const [saving,             setSaving]             = useState(false)
@@ -233,12 +237,13 @@ export default function ParametrosPage() {
     fetch('/api/sdr/settings')
       .then(r => r.ok ? r.json() : Promise.reject(r.status))
       .then((d: ApiData) => {
-        const { n8nWebhookUrl: webhookUrl, n8nDispatchUrl: dispatchUrl, n8nEnrollUrl: enrollUrl, ...coreSettings } = d.settings
+        const { n8nWebhookUrl: webhookUrl, n8nDispatchUrl: dispatchUrl, n8nEnrollUrl: enrollUrl, n8nImportUrl: importUrl, ...coreSettings } = d.settings
         setSettings({ ...DEFAULTS, ...coreSettings })
         setStatus(d.status)
         setN8nWebhookUrl(webhookUrl ?? '')
         setN8nDispatchUrl(dispatchUrl ?? '')
         setN8nEnrollUrl(enrollUrl ?? '')
+        setN8nImportUrl(importUrl ?? '')
         // secrets are never returned by GET — fields stay empty intentionally
       })
       .catch(() => {})
@@ -265,6 +270,8 @@ export default function ParametrosPage() {
         ...(n8nDispatchSecret ? { n8nDispatchSecret } : {}),
         n8nEnrollUrl,
         ...(n8nEnrollSecret ? { n8nEnrollSecret } : {}),
+        n8nImportUrl,
+        ...(n8nImportSecret ? { n8nImportSecret } : {}),
       }
       const res = await fetch('/api/sdr/settings', {
         method: 'PUT',
@@ -912,6 +919,59 @@ export default function ParametrosPage() {
           </div>
           <div style={{ fontSize: 11, color: 'var(--gray2)', fontWeight: 500, lineHeight: 1.5 }}>
             Webhook acionado pela página Leads ao adicionar leads à campanha. Deixe em branco para manter o segredo já salvo.
+          </div>
+
+          <div style={{ height: 1, background: 'var(--gray3)', margin: '24px 0' }} />
+
+          <FieldLabel>URL de importação (n8n)</FieldLabel>
+          <input
+            type="url"
+            value={n8nImportUrl}
+            onChange={e => setN8nImportUrl(e.target.value)}
+            placeholder="https://seu-n8n.example.com/webhook/..."
+            style={{
+              width: '100%', fontFamily: 'inherit', fontSize: 13,
+              border: '1px solid var(--gray3)', borderRadius: 10, padding: '10px 14px',
+              background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+              boxSizing: 'border-box', transition: 'border-color .15s', marginBottom: 20,
+            }}
+            onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+            onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+          />
+
+          <FieldLabel>Segredo de importação (opcional)</FieldLabel>
+          <div style={{ position: 'relative', marginBottom: 8 }}>
+            <input
+              type={showImportSecret ? 'text' : 'password'}
+              value={n8nImportSecret}
+              onChange={e => setN8nImportSecret(e.target.value)}
+              placeholder="••••••••"
+              autoComplete="new-password"
+              style={{
+                width: '100%', fontFamily: 'inherit', fontSize: 13,
+                border: '1px solid var(--gray3)', borderRadius: 10,
+                padding: '10px 42px 10px 14px',
+                background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+                boxSizing: 'border-box', transition: 'border-color .15s',
+              }}
+              onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+              onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+            />
+            <button
+              type="button"
+              onClick={() => setShowImportSecret(s => !s)}
+              title={showImportSecret ? 'Ocultar' : 'Mostrar'}
+              style={{
+                position: 'absolute', right: 10, top: '50%', transform: 'translateY(-50%)',
+                background: 'none', border: 'none', cursor: 'pointer',
+                color: 'var(--gray2)', padding: 4, display: 'flex', alignItems: 'center',
+              }}
+            >
+              {showImportSecret ? <EyeOff size={15} /> : <Eye size={15} />}
+            </button>
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--gray2)', fontWeight: 500, lineHeight: 1.5 }}>
+            Webhook acionado ao importar leads via Excel. Deixe em branco para manter o segredo já salvo.
           </div>
         </SectionCard>
       </CollapsibleArea>

--- a/app/api/sdr/leads/import/route.ts
+++ b/app/api/sdr/leads/import/route.ts
@@ -1,0 +1,312 @@
+// POST /api/sdr/leads/import
+//
+// Recebe multipart/form-data com campo "file" (.xlsx/.xls), parseia,
+// valida/normaliza/deduplica (ETL na app) e envia os leads NOVOS ao n8nImportUrl.
+//
+// REGRA CRÍTICA: a app nunca escreve no Supabase.
+// O SELECT no Supabase é somente para deduplicação. Inserção = responsabilidade do n8n.
+//
+// Response: { ok, totalLinhas, importados, ignorados: { total, amostra }, duplicados: { total, amostra }, n8nStatus }
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { dataSources, campaignSettings } from '@/lib/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { decrypt } from '@/lib/crypto'
+import { assertEntitlement } from '@/lib/entitlements'
+import { Client } from 'pg'
+import * as XLSX from 'xlsx'
+
+const PROVIDER_KEY   = 'supabase-n8n'
+const SOURCE         = 'sdr-n8n'
+const MAX_FILE_BYTES = 5 * 1024 * 1024  // 5 MB
+const MAX_ROWS       = 1000
+const AMOSTRA_MAX    = 20
+const E164_RE        = /^\+[1-9]\d{6,14}$/
+
+// Maps spreadsheet header (PT or EN) to internal canonical key.
+function mapKey(raw: string): string {
+  switch (raw.toLowerCase().trim()) {
+    case 'nome':     case 'name':                        return 'name'
+    case 'telefone': case 'phone': case 'tel':
+    case 'celular':                                      return 'phone'
+    case 'empresa':  case 'company':                     return 'company'
+    case 'origem':   case 'source':                      return 'source'
+    case 'status':                                       return 'status'
+    default:                                             return raw.toLowerCase().trim()
+  }
+}
+
+// Normalizes a phone string to E.164. Returns null if the result is not valid E.164.
+// Strategy: keep only digits and leading +; if no +, assume Brazil (+55) when < 12 digits.
+function normalizePhone(raw: string): string | null {
+  if (!raw) return null
+  const stripped = raw.replace(/[^\d+]/g, '')
+  if (!stripped) return null
+
+  let normalized: string
+  if (stripped.startsWith('+')) {
+    normalized = stripped
+  } else {
+    // No + prefix: use digit count to guess whether country code is present.
+    // Brazilian numbers without DDI are 10–11 digits (DDD + number).
+    // With +55 they become 12–13 digits.
+    normalized = stripped.length >= 12 ? '+' + stripped : '+55' + stripped
+  }
+
+  return E164_RE.test(normalized) ? normalized : null
+}
+
+// Canonical dedup key — format-agnostic, comparable across the file and the DB.
+// Produces DDD(2) + 8 digits, collapsing the 9th-digit mobile prefix so that
+// "+5511 9 8888-7777" and the DB value "551188887777" both yield "1188887777".
+// Returns null when the input cannot be reduced to a valid key.
+function phoneKey(raw: string): string | null {
+  if (!raw) return null
+  const digits = raw.replace(/\D/g, '')
+  if (!digits) return null
+
+  let national = digits
+
+  // Strip Brazil DDI when present and remainder is 10 or 11 digits (12/13 total)
+  if (national.startsWith('55') && (national.length === 12 || national.length === 13)) {
+    national = national.slice(2)
+  }
+
+  // Remove 9th-digit mobile prefix: DDD(2) + '9' + 8 digits → DDD(2) + 8 digits
+  if (national.length === 11 && national[2] === '9') {
+    national = national.slice(0, 2) + national.slice(3)
+  }
+
+  return national.length >= 10 ? national : null
+}
+
+export async function POST(request: Request) {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { tenantId } = session.user
+  const denied = await assertEntitlement(tenantId, 'sdr.parametros')
+  if (denied) return denied
+
+  // ── Load n8nImportUrl + secret early — prerequisite for the whole operation ───
+  const [csRow] = await db
+    .select()
+    .from(campaignSettings)
+    .where(and(eq(campaignSettings.tenantId, tenantId), eq(campaignSettings.source, SOURCE)))
+    .limit(1)
+
+  let csSettings: Record<string, unknown> = {}
+  if (csRow) {
+    try { csSettings = JSON.parse(csRow.settings) } catch {}
+  }
+
+  const importUrl =
+    typeof csSettings.n8nImportUrl === 'string' && csSettings.n8nImportUrl
+      ? csSettings.n8nImportUrl
+      : null
+
+  if (!importUrl) {
+    return NextResponse.json({ error: 'import_url_nao_configurada' }, { status: 400 })
+  }
+
+  const importSecret =
+    typeof csSettings.n8nImportSecret === 'string' && csSettings.n8nImportSecret
+      ? csSettings.n8nImportSecret
+      : undefined
+
+  // ── Parse multipart/form-data ─────────────────────────────────────────────────
+  let formData: FormData
+  try {
+    formData = await request.formData()
+  } catch {
+    return NextResponse.json({ error: 'Esperado multipart/form-data' }, { status: 400 })
+  }
+
+  const fileField = formData.get('file')
+  if (!fileField || typeof fileField === 'string') {
+    return NextResponse.json({ error: 'Campo "file" ausente ou inválido' }, { status: 400 })
+  }
+  const file = fileField as File
+
+  if (!file.name.match(/\.(xlsx|xls)$/i)) {
+    return NextResponse.json({ error: 'Arquivo deve ser .xlsx ou .xls' }, { status: 400 })
+  }
+  if (file.size > MAX_FILE_BYTES) {
+    return NextResponse.json({ error: 'Arquivo muito grande (máximo 5 MB)' }, { status: 400 })
+  }
+
+  // ── Parse xlsx ────────────────────────────────────────────────────────────────
+  let rawRows: Record<string, unknown>[]
+  try {
+    const arrayBuffer = await file.arrayBuffer()
+    const wb = XLSX.read(Buffer.from(arrayBuffer), { type: 'buffer' })
+    const wsName = wb.SheetNames[0]
+    if (!wsName) {
+      return NextResponse.json({ error: 'Arquivo sem abas' }, { status: 400 })
+    }
+    rawRows = XLSX.utils.sheet_to_json<Record<string, unknown>>(wb.Sheets[wsName], { defval: '' })
+  } catch {
+    return NextResponse.json({ error: 'Falha ao ler o arquivo xlsx' }, { status: 400 })
+  }
+
+  if (rawRows.length === 0) {
+    return NextResponse.json({ error: 'Arquivo sem linhas de dados' }, { status: 400 })
+  }
+  if (rawRows.length > MAX_ROWS) {
+    return NextResponse.json(
+      { error: `Máximo de ${MAX_ROWS} linhas por importação (arquivo tem ${rawRows.length})` },
+      { status: 400 },
+    )
+  }
+
+  // ── ETL: normalize + classify + dedup within file ────────────────────────────
+  type IgnoredEntry = { linha: number; motivo: string }
+  type DupEntry     = { linha: number; telefone: string }
+  type LeadEntry    = { name: string; phone: string; company: string; source: string; status: string }
+
+  const ignorados:  IgnoredEntry[]                               = []
+  const duplicados: DupEntry[]                                   = []
+  const candidatos: Array<LeadEntry & { linha: number; key: string }> = []
+  const seenKeys   = new Set<string>()
+
+  for (let i = 0; i < rawRows.length; i++) {
+    const linha = i + 2  // row 1 = header, data starts at row 2
+
+    // Remap spreadsheet keys to canonical names
+    const row: Record<string, string> = {}
+    for (const [k, v] of Object.entries(rawRows[i])) {
+      row[mapKey(k)] = String(v ?? '').trim()
+    }
+
+    const name    = row.name    || ''
+    const phone   = row.phone   || ''
+    const company = row.company || ''
+    const source  = row.source  || 'import'
+    const status  = row.status  || 'novo'
+
+    if (!name) {
+      ignorados.push({ linha, motivo: 'nome ausente' })
+      continue
+    }
+
+    // E.164 required for the n8n payload
+    const normalized = normalizePhone(phone)
+    if (!normalized) {
+      ignorados.push({ linha, motivo: 'telefone inválido' })
+      continue
+    }
+
+    // Canonical key for dedup (format-agnostic, matches DB phone_adjusted format)
+    const key = phoneKey(normalized)
+    if (!key) {
+      ignorados.push({ linha, motivo: 'telefone inválido' })
+      continue
+    }
+
+    // Dedup within the file (first occurrence wins)
+    if (seenKeys.has(key)) {
+      duplicados.push({ linha, telefone: normalized })
+      continue
+    }
+    seenKeys.add(key)
+
+    candidatos.push({ linha, name, phone: normalized, company, source, status, key })
+  }
+
+  // ── Dedup against Supabase (SOMENTE SELECT — nunca escreve) ──────────────────
+  // Uses phoneKey on both columns to match across heterogeneous formats:
+  // DB phone may be raw/masked; phone_adjusted is digits-only without '+'.
+  const existingKeys = new Set<string>()
+
+  if (candidatos.length > 0) {
+    const dsRow = await db
+      .select()
+      .from(dataSources)
+      .where(and(
+        eq(dataSources.tenantId, tenantId),
+        eq(dataSources.providerKey, PROVIDER_KEY),
+      ))
+      .then(r => r[0])
+
+    if (dsRow?.configEnc) {
+      let pgClient: Client | null = null
+      try {
+        const cfg = JSON.parse(decrypt(dsRow.configEnc)) as { connectionString?: string }
+        if (cfg.connectionString) {
+          pgClient = new Client({ connectionString: cfg.connectionString })
+          await pgClient.connect()
+
+          // Fetch broadly — exact-string match is unreliable across formats;
+          // phoneKey normalizes both sides in the app. SELECT only — never writes.
+          const res = await pgClient.query<{ phone: string | null; phone_adjusted: string | null }>(
+            `SELECT phone, phone_adjusted
+               FROM leads
+              WHERE phone IS NOT NULL OR phone_adjusted IS NOT NULL`,
+          )
+          for (const r of res.rows) {
+            const k1 = phoneKey(r.phone ?? '')
+            const k2 = phoneKey(r.phone_adjusted ?? '')
+            if (k1) existingKeys.add(k1)
+            if (k2) existingKeys.add(k2)
+          }
+        }
+      } catch (err) {
+        // Non-fatal: skip Supabase dedup if DB is unavailable, proceed with file-only dedup
+        console.error('[sdr import dedup]', err)
+      } finally {
+        if (pgClient) await pgClient.end().catch(() => {})
+      }
+    }
+  }
+
+  // Partition candidatos into novos (new) vs supabase-duplicates
+  const novos: LeadEntry[] = []
+  for (const c of candidatos) {
+    if (existingKeys.has(c.key)) {
+      duplicados.push({ linha: c.linha, telefone: c.phone })
+    } else {
+      novos.push({ name: c.name, phone: c.phone, company: c.company, source: c.source, status: c.status })
+    }
+  }
+
+  // ── POST new leads to n8n (app never writes to Supabase — n8n does) ──────────
+  let n8nStatus = 0
+
+  if (novos.length > 0) {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (importSecret) headers['Authorization'] = `Bearer ${importSecret}`
+    try {
+      const res = await fetch(importUrl, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ tenantId, leads: novos }),
+        signal: AbortSignal.timeout(15_000),
+      })
+      n8nStatus = res.status
+    } catch (err) {
+      console.error('[sdr import → n8n]', err)
+      return NextResponse.json(
+        { ok: false, error: 'Falha ao enviar ao n8n: ' + (err instanceof Error ? err.message : String(err)) },
+        { status: 502 },
+      )
+    }
+  }
+
+  // ── Report ────────────────────────────────────────────────────────────────────
+  return NextResponse.json({
+    ok: true,
+    totalLinhas: rawRows.length,
+    importados:  novos.length,
+    ignorados: {
+      total:   ignorados.length,
+      amostra: ignorados.slice(0, AMOSTRA_MAX),
+    },
+    duplicados: {
+      total:   duplicados.length,
+      amostra: duplicados.slice(0, AMOSTRA_MAX),
+    },
+    n8nStatus,
+  })
+}

--- a/app/api/sdr/leads/template/route.ts
+++ b/app/api/sdr/leads/template/route.ts
@@ -1,0 +1,107 @@
+// GET /api/sdr/leads/template
+//
+// Devolve um arquivo .xlsx (modelo) com as colunas PREENCHÍVEIS da tabela `leads`
+// como cabeçalho — pronto para o usuário preencher e importar.
+// Colunas de sistema (id, created_at, phone_adjusted, ativo, dealid, ...) são omitidas.
+//
+// SOMENTE LEITURA: usa apenas SELECT em information_schema. Nunca escreve.
+
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { dataSources } from '@/lib/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { decrypt } from '@/lib/crypto'
+import { assertEntitlement } from '@/lib/entitlements'
+import { Client } from 'pg'
+import * as XLSX from 'xlsx'
+
+const PROVIDER_KEY = 'supabase-n8n'
+
+// Only user-fillable columns — system columns (id, created_at, phone_adjusted, …) are excluded.
+const FILLABLE_COLUMNS = ['name', 'phone', 'company', 'source', 'status']
+
+export async function GET() {
+  const session = await auth()
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const { tenantId } = session.user
+  const denied = await assertEntitlement(tenantId, 'sdr.parametros')
+  if (denied) return denied
+
+  const row = await db
+    .select()
+    .from(dataSources)
+    .where(and(
+      eq(dataSources.tenantId, tenantId),
+      eq(dataSources.providerKey, PROVIDER_KEY),
+    ))
+    .then(r => r[0])
+
+  if (!row?.configEnc) {
+    return new Response(JSON.stringify({ error: 'fonte_sdr_nao_configurada' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  let connectionString: string
+  try {
+    const cfg = JSON.parse(decrypt(row.configEnc)) as { connectionString?: string }
+    if (!cfg.connectionString) throw new Error('connectionString ausente')
+    connectionString = cfg.connectionString
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: 'config_invalid', message: (err as Error).message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  let columns: string[] = FILLABLE_COLUMNS
+
+  const client = new Client({ connectionString })
+  try {
+    await client.connect()
+
+    const res = await client.query<{ column_name: string }>(
+      `SELECT column_name
+         FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name   = 'leads'
+        ORDER BY ordinal_position`,
+    )
+
+    if (res.rows.length > 0) {
+      const dbCols = new Set(res.rows.map(r => r.column_name.toLowerCase()))
+      const intersected = FILLABLE_COLUMNS.filter(c => dbCols.has(c.toLowerCase()))
+      // If intersection is empty (schema diverged), fall back to full allowlist
+      columns = intersected.length > 0 ? intersected : FILLABLE_COLUMNS
+    }
+  } catch (err) {
+    console.error('[sdr leads template] introspection failed, using fallback', err)
+    // columns already set to FILLABLE_COLUMNS
+  } finally {
+    await client.end().catch(() => {})
+  }
+
+  const ws = XLSX.utils.aoa_to_sheet([columns])
+  const wb = XLSX.utils.book_new()
+  XLSX.utils.book_append_sheet(wb, ws, 'Leads')
+
+  // XLSX.write returns a Node Buffer (Uint8Array<ArrayBufferLike>); copy into a plain
+  // Uint8Array<ArrayBuffer> so TypeScript accepts it as BodyInit.
+  const xlsxBuf = XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' }) as Uint8Array
+  const body    = new Uint8Array(xlsxBuf)
+
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'Content-Disposition': 'attachment; filename="modelo-leads.xlsx"',
+    },
+  })
+}

--- a/app/api/sdr/settings/route.ts
+++ b/app/api/sdr/settings/route.ts
@@ -105,8 +105,8 @@ export async function GET() {
   try { parsed = JSON.parse(row.settings) } catch {}
 
   // Omit secrets from GET response; URLs are returned for UI display
-  const { n8nWebhookSecret: _omitWS, n8nDispatchSecret: _omitDS, n8nEnrollSecret: _omitES, ...settingsForClient } = parsed
-  void _omitWS; void _omitDS; void _omitES
+  const { n8nWebhookSecret: _omitWS, n8nDispatchSecret: _omitDS, n8nEnrollSecret: _omitES, n8nImportSecret: _omitIS, ...settingsForClient } = parsed
+  void _omitWS; void _omitDS; void _omitES; void _omitIS
 
   return NextResponse.json({ configured: true, status: row.status, version: row.version, settings: settingsForClient })
 }
@@ -170,6 +170,18 @@ export async function PUT(request: Request) {
     }
   }
 
+  // Validate import URL if provided (same anti-SSRF rules)
+  if (rawSettings.n8nImportUrl !== undefined && rawSettings.n8nImportUrl !== '') {
+    try {
+      validateWebhookUrl(rawSettings.n8nImportUrl)
+    } catch (err) {
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : 'n8nImportUrl inválida' },
+        { status: 400 },
+      )
+    }
+  }
+
   // Validate remetente E.164 if provided and non-empty
   if (rawSettings.remetente !== undefined && rawSettings.remetente !== '') {
     if (typeof rawSettings.remetente !== 'string' || !E164_RE.test(rawSettings.remetente)) {
@@ -191,7 +203,7 @@ export async function PUT(request: Request) {
 
   // Preserve stored secrets when the incoming PUT omits or clears them.
   // (GET strips secrets, so the UI cannot re-send them on subsequent saves.)
-  if (existing && (!rawSettings.n8nWebhookSecret || !rawSettings.n8nDispatchSecret || !rawSettings.n8nEnrollSecret)) {
+  if (existing && (!rawSettings.n8nWebhookSecret || !rawSettings.n8nDispatchSecret || !rawSettings.n8nEnrollSecret || !rawSettings.n8nImportSecret)) {
     try {
       const stored = JSON.parse(existing.settings) as Record<string, unknown>
       if (!rawSettings.n8nWebhookSecret && typeof stored.n8nWebhookSecret === 'string' && stored.n8nWebhookSecret) {
@@ -202,6 +214,9 @@ export async function PUT(request: Request) {
       }
       if (!rawSettings.n8nEnrollSecret && typeof stored.n8nEnrollSecret === 'string' && stored.n8nEnrollSecret) {
         rawSettings.n8nEnrollSecret = stored.n8nEnrollSecret
+      }
+      if (!rawSettings.n8nImportSecret && typeof stored.n8nImportSecret === 'string' && stored.n8nImportSecret) {
+        rawSettings.n8nImportSecret = stored.n8nImportSecret
       }
     } catch { /* corrupt stored JSON — skip merge */ }
   }
@@ -250,9 +265,11 @@ export async function PUT(request: Request) {
       n8nDispatchSecret: _ds,
       n8nEnrollUrl: _eu,
       n8nEnrollSecret: _es,
+      n8nImportUrl: _iu,
+      n8nImportSecret: _is,
       ...settingsPayload
     } = rawSettings
-    void _u; void _s; void _du; void _ds; void _eu; void _es
+    void _u; void _s; void _du; void _ds; void _eu; void _es; void _iu; void _is
     const payload = {
       tenantId,
       status,

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "recharts": "^3.8.1",
+        "xlsx": "^0.18.5",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -1989,6 +1990,15 @@
         "node": ">= 20"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/bcryptjs": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
@@ -2025,6 +2035,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -2038,6 +2061,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -2432,6 +2476,15 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fsevents": {
@@ -3481,6 +3534,18 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -4122,6 +4187,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ws": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
@@ -4166,6 +4249,27 @@
       },
       "engines": {
         "node": ">= 6.0"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "recharts": "^3.8.1",
+    "xlsx": "^0.18.5",
     "zustand": "^5.0.12"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Instala `xlsx` (SheetJS) para parse de planilhas Excel
- `GET /api/sdr/leads/template` — baixa modelo `.xlsx` com as 5 colunas preenchíveis (`name`, `phone`, `company`, `source`, `status`) via introspecção do `information_schema`; fallback para a allowlist se o DB estiver indisponível
- `POST /api/sdr/leads/import` — ETL completo: normalização E.164, `phoneKey()` para dedup robusto a formato (colapsa 9º dígito celular, strip DDI `55`), dedup in-file e contra Supabase via `SELECT`; envia leads novos ao `n8nImportUrl`; **app nunca escreve no Supabase**
- `app/api/sdr/settings/route.ts` — adiciona `n8nImportUrl`/`n8nImportSecret` (validação anti-SSRF, GET strip, PUT preserve-on-omit, exclusão do payload n8n)
- `app/(app)/sdr-ia/parametros/page.tsx` — campos URL + segredo de importação na seção "Integrações n8n"
- `app/(app)/sdr-ia/leads/page.tsx` — botões "Baixar modelo" e "Importar Excel", painel de relatório (importados/ignorados/duplicados com amostras expansíveis), aviso âmbar quando n8n retorna HTTP não-2xx, refetch automático após importação

## Test plan

- [ ] Baixar modelo → arquivo `.xlsx` com cabeçalho `name | phone | company | source | status`
- [ ] Importar planilha válida → relatório mostra contadores corretos; lista recarrega
- [ ] Telefone inválido/sem nome → linha aparece em "ignorados" com motivo
- [ ] Telefone já existente no Supabase → aparece em "duplicados"
- [ ] Mesmo telefone em formatos diferentes no arquivo → apenas 1ª ocorrência importada
- [ ] Sem `n8nImportUrl` configurada → erro `400 import_url_nao_configurada` com mensagem amigável
- [ ] n8n retorna HTTP 5xx → painel âmbar com aviso de falha no webhook
- [ ] Todos duplicados/ignorados (importados = 0) → painel verde sem falso aviso de n8n

🤖 Generated with [Claude Code](https://claude.com/claude-code)