### PR TITLE
feat: import e disparo em massa de leads + templates

### DIFF
--- a/app/(app)/sdr-ia/leads/page.tsx
+++ b/app/(app)/sdr-ia/leads/page.tsx
@@ -46,6 +46,16 @@ function friendlyImportError(code: string): string {
   return code
 }
 
+function friendlyBlastError(code: string): string {
+  if (code === 'blast_url_nao_configurada')
+    return 'URL de disparo de lista n8n não configurada — acesse Parâmetros > Integrações n8n.'
+  if (code === 'remetente_nao_configurado')
+    return 'Remetente não configurado na campanha — defina em Parâmetros.'
+  if (code === 'fonte_sdr_nao_configurada')
+    return 'Fonte de dados SDR não configurada — acesse Configurações > Integrações.'
+  return code
+}
+
 function StatusBadge({ value }: { value: string | null }) {
   if (!value) return <span style={{ color: 'var(--gray3)', fontSize: 11 }}>—</span>
   const colors: Record<string, { bg: string; color: string }> = {
@@ -85,6 +95,17 @@ export default function LeadsPage() {
   const [campaignEnrolling,    setCampaignEnrolling]    = useState(false)
   const [campaignEnrollResult, setCampaignEnrollResult] = useState<{
     ok: boolean; enrolled?: number; partialError?: string; error?: string
+  } | null>(null)
+
+  // Blast (disparo direto de template à lista importada)
+  const [blastMode,        setBlastMode]        = useState(false)
+  const [blastTemplates,   setBlastTemplates]   = useState<{ nome_template: string; preview: string; fase_envio: string | null }[] | null>(null)
+  const [blastTplLoading,  setBlastTplLoading]  = useState(false)
+  const [blastTplError,    setBlastTplError]    = useState<string | null>(null)
+  const [selectedTemplate, setSelectedTemplate] = useState('')
+  const [blasting,         setBlasting]         = useState(false)
+  const [blastResult,      setBlastResult]      = useState<{
+    ok: boolean; started?: number; totalSolicitado?: number; skipped?: number; error?: string
   } | null>(null)
 
   const masterRef   = useRef<HTMLInputElement>(null)
@@ -212,6 +233,57 @@ export default function LeadsPage() {
       })
     }
     setCampaignEnrolling(false)
+  }
+
+  function closeCampaignModal() {
+    setShowCampaignModal(false)
+    setCampaignEnrollResult(null)
+    setBlastMode(false)
+    setBlastResult(null)
+    setSelectedTemplate('')
+  }
+
+  async function openBlast() {
+    setBlastMode(true)
+    setBlastResult(null)
+    setSelectedTemplate('')
+    if (blastTemplates) return  // já carregado
+    setBlastTplLoading(true)
+    setBlastTplError(null)
+    try {
+      const res = await fetch('/api/sdr/templates')
+      const data = await res.json() as { items?: { nome_template: string; preview: string; fase_envio: string | null }[]; error?: string }
+      if (!res.ok) { setBlastTplError(data.error ?? `HTTP ${res.status}`); return }
+      setBlastTemplates(data.items ?? [])
+    } catch (e) {
+      setBlastTplError((e as Error).message)
+    } finally {
+      setBlastTplLoading(false)
+    }
+  }
+
+  async function runBlast() {
+    const ids = importResult?.leadIds ?? []
+    if (ids.length === 0 || !selectedTemplate) return
+    setBlasting(true)
+    setBlastResult(null)
+    try {
+      const res = await fetch('/api/sdr/leads/blast', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ leadIds: ids, template: selectedTemplate }),
+      })
+      const data = await res.json() as { ok: boolean; started?: number; totalSolicitado?: number; skipped?: number; error?: string }
+      if (res.ok && data.ok) {
+        setBlastResult({ ok: true, started: data.started, totalSolicitado: data.totalSolicitado, skipped: data.skipped })
+      } else {
+        setBlastResult({ ok: false, error: data.error ?? `HTTP ${res.status}`, skipped: data.skipped })
+      }
+    } catch (e) {
+      setBlastResult({ ok: false, error: (e as Error).message })
+    } finally {
+      setBlasting(false)
+    }
   }
 
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -638,10 +710,7 @@ export default function LeadsPage() {
       {/* ── Campaign enroll modal ─────────────────────────────────── */}
       {showCampaignModal && (
         <div
-          onClick={campaignEnrolling ? undefined : () => {
-            setShowCampaignModal(false)
-            setCampaignEnrollResult(null)
-          }}
+          onClick={(campaignEnrolling || blasting) ? undefined : closeCampaignModal}
           style={{
             position: 'fixed', inset: 0, zIndex: 1000,
             background: 'rgba(0,0,0,0.45)',
@@ -657,84 +726,212 @@ export default function LeadsPage() {
               maxWidth: 440, width: '100%',
             }}
           >
-            {/* Title */}
-            <div style={{
-              fontSize: 18, fontWeight: 800, color: 'var(--black)',
-              letterSpacing: '-0.01em', marginBottom: 10,
-            }}>
-              {importResult?.importados} lead{importResult?.importados !== 1 ? 's' : ''} importados — adicionar à campanha?
-            </div>
+            {!blastMode ? (
+              <>
+                {/* Title */}
+                <div style={{
+                  fontSize: 18, fontWeight: 800, color: 'var(--black)',
+                  letterSpacing: '-0.01em', marginBottom: 10,
+                }}>
+                  {importResult?.importados} lead{importResult?.importados !== 1 ? 's' : ''} importados — o que fazer?
+                </div>
 
-            {/* Description */}
-            <div style={{ fontSize: 13, color: 'var(--gray)', lineHeight: 1.65, marginBottom: 24 }}>
-              Clicar em <strong>Adicionar à campanha agora</strong> coloca esses leads na fila
-              de disparo SDR (Template 1). Você também pode fazer isso depois selecionando-os
-              manualmente na lista.
-            </div>
+                {/* Description */}
+                <div style={{ fontSize: 13, color: 'var(--gray)', lineHeight: 1.65, marginBottom: 24 }}>
+                  <strong>Adicionar à campanha</strong> coloca esses leads na fila de disparo SDR
+                  (Template 1, agendado). <strong>Disparar mensagens</strong> envia um template
+                  aprovado agora para toda a lista.
+                </div>
 
-            {/* Loading */}
-            {campaignEnrolling && (
-              <div style={{ fontSize: 13, color: 'var(--gray2)', marginBottom: 20 }}>
-                Adicionando...
-              </div>
-            )}
-
-            {/* Result */}
-            {campaignEnrollResult && (
-              <div style={{
-                marginBottom: 20, padding: '10px 14px', borderRadius: 10, fontSize: 13, fontWeight: 600,
-                background: campaignEnrollResult.ok ? 'rgba(34,197,94,0.08)' : 'rgba(239,68,68,0.08)',
-                border: `1px solid ${campaignEnrollResult.ok ? 'rgba(34,197,94,0.25)' : 'rgba(239,68,68,0.25)'}`,
-                color: campaignEnrollResult.ok ? '#15803d' : 'var(--red)',
-              }}>
-                {campaignEnrollResult.ok
-                  ? `✓ ${campaignEnrollResult.enrolled} lead${campaignEnrollResult.enrolled !== 1 ? 's' : ''} adicionados à campanha`
-                  : `Erro ao adicionar: ${campaignEnrollResult.error}`
-                }
-                {campaignEnrollResult.partialError && (
-                  <div style={{ fontSize: 11, color: '#b45309', marginTop: 6, fontWeight: 500 }}>
-                    Alguns lotes falharam: {campaignEnrollResult.partialError}
+                {/* Loading */}
+                {campaignEnrolling && (
+                  <div style={{ fontSize: 13, color: 'var(--gray2)', marginBottom: 20 }}>
+                    Adicionando...
                   </div>
                 )}
-              </div>
+
+                {/* Result */}
+                {campaignEnrollResult && (
+                  <div style={{
+                    marginBottom: 20, padding: '10px 14px', borderRadius: 10, fontSize: 13, fontWeight: 600,
+                    background: campaignEnrollResult.ok ? 'rgba(34,197,94,0.08)' : 'rgba(239,68,68,0.08)',
+                    border: `1px solid ${campaignEnrollResult.ok ? 'rgba(34,197,94,0.25)' : 'rgba(239,68,68,0.25)'}`,
+                    color: campaignEnrollResult.ok ? '#15803d' : 'var(--red)',
+                  }}>
+                    {campaignEnrollResult.ok
+                      ? `✓ ${campaignEnrollResult.enrolled} lead${campaignEnrollResult.enrolled !== 1 ? 's' : ''} adicionados à campanha`
+                      : `Erro ao adicionar: ${campaignEnrollResult.error}`
+                    }
+                    {campaignEnrollResult.partialError && (
+                      <div style={{ fontSize: 11, color: '#b45309', marginTop: 6, fontWeight: 500 }}>
+                        Alguns lotes falharam: {campaignEnrollResult.partialError}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Actions */}
+                <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', flexWrap: 'wrap' }}>
+                  <button
+                    onClick={closeCampaignModal}
+                    disabled={campaignEnrolling}
+                    style={{
+                      padding: '10px 20px', borderRadius: 99, fontFamily: 'inherit',
+                      fontSize: 13, fontWeight: 700,
+                      border: '1px solid var(--gray3)', background: 'transparent',
+                      color: 'var(--gray)', cursor: campaignEnrolling ? 'not-allowed' : 'pointer',
+                      opacity: campaignEnrolling ? 0.5 : 1,
+                    }}
+                  >
+                    {campaignEnrollResult ? 'Fechar' : 'Só manter na lista'}
+                  </button>
+
+                  {!campaignEnrollResult && (
+                    <>
+                      <button
+                        onClick={openBlast}
+                        disabled={campaignEnrolling}
+                        style={{
+                          padding: '10px 20px', borderRadius: 99, fontFamily: 'inherit',
+                          fontSize: 13, fontWeight: 700,
+                          border: '1px solid var(--primary)', background: 'transparent',
+                          color: 'var(--primary)', cursor: campaignEnrolling ? 'not-allowed' : 'pointer',
+                          opacity: campaignEnrolling ? 0.6 : 1,
+                        }}
+                      >
+                        Disparar mensagens agora
+                      </button>
+                      <button
+                        onClick={enrollImported}
+                        disabled={campaignEnrolling}
+                        style={{
+                          padding: '10px 22px', borderRadius: 99, fontFamily: 'inherit',
+                          fontSize: 13, fontWeight: 800, border: 'none',
+                          background: campaignEnrolling ? 'var(--gray3)' : 'var(--primary)',
+                          color: campaignEnrolling ? 'var(--gray2)' : 'var(--white)',
+                          cursor: campaignEnrolling ? 'not-allowed' : 'pointer',
+                          opacity: campaignEnrolling ? 0.7 : 1,
+                        }}
+                      >
+                        Adicionar à campanha
+                      </button>
+                    </>
+                  )}
+                </div>
+              </>
+            ) : (
+              <>
+                {/* Blast sub-view */}
+                <div style={{
+                  fontSize: 18, fontWeight: 800, color: 'var(--black)',
+                  letterSpacing: '-0.01em', marginBottom: 10,
+                }}>
+                  Disparar para {importResult?.leadIds?.length ?? 0} contato{(importResult?.leadIds?.length ?? 0) !== 1 ? 's' : ''}
+                </div>
+                <div style={{ fontSize: 13, color: 'var(--gray)', lineHeight: 1.65, marginBottom: 18 }}>
+                  Envio real de WhatsApp usando um <strong>template aprovado</strong> para toda a
+                  lista importada. O n8n envia com um pequeno intervalo entre mensagens.
+                </div>
+
+                {blastTplLoading && (
+                  <div style={{ fontSize: 13, color: 'var(--gray2)', marginBottom: 18 }}>Carregando templates...</div>
+                )}
+                {blastTplError && (
+                  <div style={{
+                    marginBottom: 18, padding: '10px 14px', borderRadius: 10, fontSize: 13, fontWeight: 600,
+                    background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.25)', color: 'var(--red)',
+                  }}>
+                    {friendlyBlastError(blastTplError)}
+                  </div>
+                )}
+
+                {blastTemplates && !blastResult && (
+                  <div style={{ marginBottom: 18 }}>
+                    <select
+                      value={selectedTemplate}
+                      onChange={e => setSelectedTemplate(e.target.value)}
+                      disabled={blasting}
+                      style={{
+                        width: '100%', padding: '10px 12px', borderRadius: 10, fontFamily: 'inherit',
+                        fontSize: 13, border: '1px solid var(--gray3)', background: 'var(--white)', color: 'var(--black)',
+                      }}
+                    >
+                      <option value="">Escolha um template…</option>
+                      {blastTemplates.map(t => (
+                        <option key={t.nome_template} value={t.nome_template}>{t.nome_template}</option>
+                      ))}
+                    </select>
+                    {(() => {
+                      const tpl = blastTemplates.find(t => t.nome_template === selectedTemplate)
+                      return tpl?.preview ? (
+                        <div style={{
+                          marginTop: 10, padding: '10px 14px', borderRadius: 10, fontSize: 12.5,
+                          color: 'var(--gray)', background: 'rgba(0,0,0,0.04)',
+                          border: '1px solid rgba(0,0,0,0.08)', lineHeight: 1.55,
+                        }}>
+                          {tpl.preview}
+                        </div>
+                      ) : null
+                    })()}
+                  </div>
+                )}
+
+                {blasting && (
+                  <div style={{ fontSize: 13, color: 'var(--gray2)', marginBottom: 18 }}>Disparando...</div>
+                )}
+                {blastResult && (
+                  <div style={{
+                    marginBottom: 18, padding: '10px 14px', borderRadius: 10, fontSize: 13, fontWeight: 600,
+                    background: blastResult.ok ? 'rgba(34,197,94,0.08)' : 'rgba(239,68,68,0.08)',
+                    border: `1px solid ${blastResult.ok ? 'rgba(34,197,94,0.25)' : 'rgba(239,68,68,0.25)'}`,
+                    color: blastResult.ok ? '#15803d' : 'var(--red)',
+                  }}>
+                    {blastResult.ok
+                      ? `✓ Disparo iniciado para ${blastResult.started} contato${blastResult.started !== 1 ? 's' : ''}`
+                      : `Erro ao disparar: ${friendlyBlastError(blastResult.error ?? 'erro desconhecido')}`
+                    }
+                    {blastResult.ok && (blastResult.skipped ?? 0) > 0 && (
+                      <div style={{ fontSize: 11, color: '#b45309', marginTop: 6, fontWeight: 500 }}>
+                        {blastResult.skipped} ignorado(s) por telefone inválido.
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Actions */}
+                <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', flexWrap: 'wrap' }}>
+                  <button
+                    onClick={() => { if (blastResult) { closeCampaignModal() } else { setBlastMode(false) } }}
+                    disabled={blasting}
+                    style={{
+                      padding: '10px 20px', borderRadius: 99, fontFamily: 'inherit',
+                      fontSize: 13, fontWeight: 700,
+                      border: '1px solid var(--gray3)', background: 'transparent',
+                      color: 'var(--gray)', cursor: blasting ? 'not-allowed' : 'pointer',
+                      opacity: blasting ? 0.5 : 1,
+                    }}
+                  >
+                    {blastResult ? 'Fechar' : 'Voltar'}
+                  </button>
+                  {!blastResult && (
+                    <button
+                      onClick={runBlast}
+                      disabled={blasting || !selectedTemplate}
+                      style={{
+                        padding: '10px 22px', borderRadius: 99, fontFamily: 'inherit',
+                        fontSize: 13, fontWeight: 800, border: 'none',
+                        background: (blasting || !selectedTemplate) ? 'var(--gray3)' : 'var(--primary)',
+                        color: (blasting || !selectedTemplate) ? 'var(--gray2)' : 'var(--white)',
+                        cursor: (blasting || !selectedTemplate) ? 'not-allowed' : 'pointer',
+                        opacity: (blasting || !selectedTemplate) ? 0.7 : 1,
+                      }}
+                    >
+                      Disparar
+                    </button>
+                  )}
+                </div>
+              </>
             )}
-
-            {/* Actions */}
-            <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', flexWrap: 'wrap' }}>
-              <button
-                onClick={() => {
-                  setShowCampaignModal(false)
-                  setCampaignEnrollResult(null)
-                }}
-                disabled={campaignEnrolling}
-                style={{
-                  padding: '10px 20px', borderRadius: 99, fontFamily: 'inherit',
-                  fontSize: 13, fontWeight: 700,
-                  border: '1px solid var(--gray3)', background: 'transparent',
-                  color: 'var(--gray)', cursor: campaignEnrolling ? 'not-allowed' : 'pointer',
-                  opacity: campaignEnrolling ? 0.5 : 1,
-                }}
-              >
-                {campaignEnrollResult ? 'Fechar' : 'Só manter na lista'}
-              </button>
-
-              {!campaignEnrollResult && (
-                <button
-                  onClick={enrollImported}
-                  disabled={campaignEnrolling}
-                  style={{
-                    padding: '10px 22px', borderRadius: 99, fontFamily: 'inherit',
-                    fontSize: 13, fontWeight: 800, border: 'none',
-                    background: campaignEnrolling ? 'var(--gray3)' : 'var(--primary)',
-                    color: campaignEnrolling ? 'var(--gray2)' : 'var(--white)',
-                    cursor: campaignEnrolling ? 'not-allowed' : 'pointer',
-                    opacity: campaignEnrolling ? 0.7 : 1,
-                  }}
-                >
-                  Adicionar à campanha agora
-                </button>
-              )}
-            </div>
           </div>
         </div>
       )}

--- a/app/(app)/sdr-ia/parametros/page.tsx
+++ b/app/(app)/sdr-ia/parametros/page.tsx
@@ -25,6 +25,7 @@ interface Settings {
   n8nDispatchUrl?:  string
   n8nEnrollUrl?:    string
   n8nImportUrl?:    string
+  n8nBlastUrl?:     string
 }
 
 interface ApiData {
@@ -175,6 +176,9 @@ export default function ParametrosPage() {
   const [n8nImportUrl,       setN8nImportUrl]       = useState('')
   const [n8nImportSecret,    setN8nImportSecret]    = useState('')
   const [showImportSecret,   setShowImportSecret]   = useState(false)
+  const [n8nBlastUrl,        setN8nBlastUrl]        = useState('')
+  const [n8nBlastSecret,     setN8nBlastSecret]     = useState('')
+  const [showBlastSecret,    setShowBlastSecret]    = useState(false)
   const [remetenteError,     setRemetenteError]     = useState<string | null>(null)
   const [loading,            setLoading]            = useState(true)
   const [saving,             setSaving]             = useState(false)
@@ -237,13 +241,14 @@ export default function ParametrosPage() {
     fetch('/api/sdr/settings')
       .then(r => r.ok ? r.json() : Promise.reject(r.status))
       .then((d: ApiData) => {
-        const { n8nWebhookUrl: webhookUrl, n8nDispatchUrl: dispatchUrl, n8nEnrollUrl: enrollUrl, n8nImportUrl: importUrl, ...coreSettings } = d.settings
+        const { n8nWebhookUrl: webhookUrl, n8nDispatchUrl: dispatchUrl, n8nEnrollUrl: enrollUrl, n8nImportUrl: importUrl, n8nBlastUrl: blastUrl, ...coreSettings } = d.settings
         setSettings({ ...DEFAULTS, ...coreSettings })
         setStatus(d.status)
         setN8nWebhookUrl(webhookUrl ?? '')
         setN8nDispatchUrl(dispatchUrl ?? '')
         setN8nEnrollUrl(enrollUrl ?? '')
         setN8nImportUrl(importUrl ?? '')
+        setN8nBlastUrl(blastUrl ?? '')
         // secrets are never returned by GET — fields stay empty intentionally
       })
       .catch(() => {})
@@ -272,6 +277,8 @@ export default function ParametrosPage() {
         ...(n8nEnrollSecret ? { n8nEnrollSecret } : {}),
         n8nImportUrl,
         ...(n8nImportSecret ? { n8nImportSecret } : {}),
+        n8nBlastUrl,
+        ...(n8nBlastSecret ? { n8nBlastSecret } : {}),
       }
       const res = await fetch('/api/sdr/settings', {
         method: 'PUT',
@@ -972,6 +979,59 @@ export default function ParametrosPage() {
           </div>
           <div style={{ fontSize: 11, color: 'var(--gray2)', fontWeight: 500, lineHeight: 1.5 }}>
             Webhook acionado ao importar leads via Excel. Deixe em branco para manter o segredo já salvo.
+          </div>
+
+          <div style={{ height: 1, background: 'var(--gray3)', margin: '24px 0' }} />
+
+          <FieldLabel>URL de disparo de lista (n8n)</FieldLabel>
+          <input
+            type="url"
+            value={n8nBlastUrl}
+            onChange={e => setN8nBlastUrl(e.target.value)}
+            placeholder="https://seu-n8n.example.com/webhook/..."
+            style={{
+              width: '100%', fontFamily: 'inherit', fontSize: 13,
+              border: '1px solid var(--gray3)', borderRadius: 10, padding: '10px 14px',
+              background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+              boxSizing: 'border-box', transition: 'border-color .15s', marginBottom: 20,
+            }}
+            onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+            onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+          />
+
+          <FieldLabel>Segredo (opcional)</FieldLabel>
+          <div style={{ position: 'relative', marginBottom: 8 }}>
+            <input
+              type={showBlastSecret ? 'text' : 'password'}
+              value={n8nBlastSecret}
+              onChange={e => setN8nBlastSecret(e.target.value)}
+              placeholder="••••••••"
+              autoComplete="new-password"
+              style={{
+                width: '100%', fontFamily: 'inherit', fontSize: 13,
+                border: '1px solid var(--gray3)', borderRadius: 10,
+                padding: '10px 42px 10px 14px',
+                background: 'var(--bg)', color: 'var(--black)', outline: 'none',
+                boxSizing: 'border-box', transition: 'border-color .15s',
+              }}
+              onFocus={e => (e.currentTarget.style.borderColor = 'var(--primary)')}
+              onBlur={e  => (e.currentTarget.style.borderColor = 'var(--gray3)')}
+            />
+            <button
+              type="button"
+              onClick={() => setShowBlastSecret(s => !s)}
+              title={showBlastSecret ? 'Ocultar' : 'Mostrar'}
+              style={{
+                position: 'absolute', right: 10, top: '50%', transform: 'translateY(-50%)',
+                background: 'none', border: 'none', cursor: 'pointer',
+                color: 'var(--gray2)', padding: 4, display: 'flex', alignItems: 'center',
+              }}
+            >
+              {showBlastSecret ? <EyeOff size={15} /> : <Eye size={15} />}
+            </button>
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--gray2)', fontWeight: 500, lineHeight: 1.5 }}>
+            Recebe a lista de contatos para blast direto de template. Deixe em branco para manter o segredo já salvo.
           </div>
         </SectionCard>
       </CollapsibleArea>

--- a/app/api/sdr/leads/blast/route.ts
+++ b/app/api/sdr/leads/blast/route.ts
@@ -1,0 +1,200 @@
+// POST /api/sdr/leads/blast
+//
+// Dispara um template aprovado do WhatsApp para uma LISTA específica de leads
+// (blast direto, fora da fila/campanha SDR). A app resolve os destinatários
+// (telefone E.164 + first_name) e o remetente, e envia ao webhook n8nBlastUrl,
+// que faz o envio via YCloud com throttle.
+//
+// REGRA CRÍTICA: a app NUNCA escreve no Supabase — apenas LÊ (leads + remetente).
+// O envio é responsabilidade do n8n.
+//
+// Body:     { leadIds: string[], template: string }
+// Response: { ok, started, totalSolicitado, skipped }
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { dataSources, campaignSettings } from '@/lib/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { decrypt } from '@/lib/crypto'
+import { assertEntitlement } from '@/lib/entitlements'
+import { Client } from 'pg'
+
+const PROVIDER_KEY = 'supabase-n8n'
+const SOURCE       = 'sdr-n8n'
+const MAX_LEADS    = 1000
+const UUID_RE      = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const E164_RE      = /^\+[1-9]\d{6,14}$/
+
+interface LeadRow {
+  id:             string
+  name:           string | null
+  phone:          string | null
+  phone_adjusted: string | null
+}
+
+// Normalize a lead's stored phone to E.164. Returns null when not usable.
+function toE164(phone: string | null, phoneAdjusted: string | null): string | null {
+  const raw = (phone ?? '').trim()
+  if (raw.startsWith('+') && E164_RE.test(raw)) return raw
+  const digits = (phoneAdjusted ?? phone ?? '').replace(/\D/g, '')
+  if (!digits) return null
+  const e164 = '+' + digits
+  return E164_RE.test(e164) ? e164 : null
+}
+
+export async function POST(request: Request) {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { tenantId } = session.user
+  const denied = await assertEntitlement(tenantId, 'sdr.parametros')
+  if (denied) return denied
+
+  let body: { leadIds?: unknown; template?: unknown }
+  try { body = await request.json() } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const template = typeof body.template === 'string' ? body.template.trim() : ''
+  if (!template) {
+    return NextResponse.json({ error: 'template é obrigatório' }, { status: 400 })
+  }
+
+  if (!Array.isArray(body.leadIds) || body.leadIds.length === 0) {
+    return NextResponse.json({ error: 'leadIds deve ser um array não vazio' }, { status: 400 })
+  }
+  if (body.leadIds.length > MAX_LEADS) {
+    return NextResponse.json({ error: `máximo de ${MAX_LEADS} leads por disparo` }, { status: 400 })
+  }
+
+  const leadIds = (body.leadIds as unknown[])
+    .filter((id): id is string => typeof id === 'string' && UUID_RE.test(id))
+  if (leadIds.length === 0) {
+    return NextResponse.json({ error: 'nenhum leadId válido (UUID esperado)' }, { status: 400 })
+  }
+
+  // ── Load n8nBlastUrl + secret from campaign settings ──────────────────────────
+  const [csRow] = await db
+    .select()
+    .from(campaignSettings)
+    .where(and(eq(campaignSettings.tenantId, tenantId), eq(campaignSettings.source, SOURCE)))
+    .limit(1)
+
+  let csSettings: Record<string, unknown> = {}
+  if (csRow) {
+    try { csSettings = JSON.parse(csRow.settings) } catch {}
+  }
+
+  const blastUrl =
+    typeof csSettings.n8nBlastUrl === 'string' && csSettings.n8nBlastUrl
+      ? csSettings.n8nBlastUrl
+      : null
+  if (!blastUrl) {
+    return NextResponse.json({ error: 'blast_url_nao_configurada' }, { status: 400 })
+  }
+  const blastSecret =
+    typeof csSettings.n8nBlastSecret === 'string' && csSettings.n8nBlastSecret
+      ? csSettings.n8nBlastSecret
+      : undefined
+
+  // ── Load Supabase connection string ───────────────────────────────────────────
+  const dsRow = await db
+    .select()
+    .from(dataSources)
+    .where(and(eq(dataSources.tenantId, tenantId), eq(dataSources.providerKey, PROVIDER_KEY)))
+    .then(r => r[0])
+
+  if (!dsRow?.configEnc) {
+    return NextResponse.json({ error: 'fonte_sdr_nao_configurada' }, { status: 400 })
+  }
+
+  let connectionString: string
+  try {
+    const cfg = JSON.parse(decrypt(dsRow.configEnc)) as { connectionString?: string }
+    if (!cfg.connectionString) throw new Error('connectionString ausente')
+    connectionString = cfg.connectionString
+  } catch (err) {
+    return NextResponse.json(
+      { error: 'config_invalid', message: (err as Error).message },
+      { status: 500 },
+    )
+  }
+
+  // ── Resolve remetente + recipients (SOMENTE SELECT — nunca escreve) ───────────
+  const client = new Client({ connectionString })
+  let recipients: { phone: string; first_name: string }[]
+  let remetente: string
+
+  try {
+    await client.connect()
+
+    const cfgRes = await client.query<{ remetente: string | null }>(
+      `SELECT remetente FROM campaign_config ORDER BY updated_at DESC LIMIT 1`,
+    )
+    const rem = cfgRes.rows[0]?.remetente?.trim()
+    if (!rem) {
+      return NextResponse.json({ error: 'remetente_nao_configurado' }, { status: 400 })
+    }
+    remetente = rem
+
+    const leadsRes = await client.query<LeadRow>(
+      `SELECT id, name, phone, phone_adjusted FROM leads WHERE id = ANY($1)`,
+      [leadIds],
+    )
+
+    recipients = []
+    for (const r of leadsRes.rows) {
+      const phone = toE164(r.phone, r.phone_adjusted)
+      if (!phone) continue  // sem telefone válido → skip
+      const first_name = (r.name ?? '').trim().split(/\s+/)[0] ?? ''
+      recipients.push({ phone, first_name })
+    }
+  } catch (err) {
+    console.error('[sdr blast resolve]', err)
+    return NextResponse.json(
+      { error: 'db_error', message: (err as Error).message },
+      { status: 502 },
+    )
+  } finally {
+    await client.end().catch(() => {})
+  }
+
+  const skipped = leadIds.length - recipients.length
+  if (recipients.length === 0) {
+    return NextResponse.json(
+      { ok: false, error: 'nenhum destinatário com telefone válido', totalSolicitado: leadIds.length, skipped },
+      { status: 400 },
+    )
+  }
+
+  // ── Trigger blast on n8n (app never sends WhatsApp directly — n8n does) ───────
+  try {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (blastSecret) headers['Authorization'] = `Bearer ${blastSecret}`
+
+    const res = await fetch(blastUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ tenantId, template, remetente, recipients }),
+      signal: AbortSignal.timeout(15_000),
+    })
+
+    let started: number | undefined
+    try {
+      const data = await res.json() as Record<string, unknown>
+      if (typeof data.started === 'number') started = data.started
+    } catch { /* n8n resposta sem corpo/JSON */ }
+
+    return NextResponse.json({
+      ok:              res.ok,
+      started:         started ?? recipients.length,
+      totalSolicitado: leadIds.length,
+      skipped,
+    })
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err)
+    console.error('[sdr blast → n8n]', error)
+    return NextResponse.json({ ok: false, error, totalSolicitado: leadIds.length, skipped }, { status: 502 })
+  }
+}

--- a/app/api/sdr/settings/route.ts
+++ b/app/api/sdr/settings/route.ts
@@ -105,8 +105,8 @@ export async function GET() {
   try { parsed = JSON.parse(row.settings) } catch {}
 
   // Omit secrets from GET response; URLs are returned for UI display
-  const { n8nWebhookSecret: _omitWS, n8nDispatchSecret: _omitDS, n8nEnrollSecret: _omitES, n8nImportSecret: _omitIS, ...settingsForClient } = parsed
-  void _omitWS; void _omitDS; void _omitES; void _omitIS
+  const { n8nWebhookSecret: _omitWS, n8nDispatchSecret: _omitDS, n8nEnrollSecret: _omitES, n8nImportSecret: _omitIS, n8nBlastSecret: _omitBS, ...settingsForClient } = parsed
+  void _omitWS; void _omitDS; void _omitES; void _omitIS; void _omitBS
 
   return NextResponse.json({ configured: true, status: row.status, version: row.version, settings: settingsForClient })
 }
@@ -182,6 +182,18 @@ export async function PUT(request: Request) {
     }
   }
 
+  // Validate blast URL if provided (same anti-SSRF rules)
+  if (rawSettings.n8nBlastUrl !== undefined && rawSettings.n8nBlastUrl !== '') {
+    try {
+      validateWebhookUrl(rawSettings.n8nBlastUrl)
+    } catch (err) {
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : 'n8nBlastUrl inválida' },
+        { status: 400 },
+      )
+    }
+  }
+
   // Validate remetente E.164 if provided and non-empty
   if (rawSettings.remetente !== undefined && rawSettings.remetente !== '') {
     if (typeof rawSettings.remetente !== 'string' || !E164_RE.test(rawSettings.remetente)) {
@@ -203,7 +215,7 @@ export async function PUT(request: Request) {
 
   // Preserve stored secrets when the incoming PUT omits or clears them.
   // (GET strips secrets, so the UI cannot re-send them on subsequent saves.)
-  if (existing && (!rawSettings.n8nWebhookSecret || !rawSettings.n8nDispatchSecret || !rawSettings.n8nEnrollSecret || !rawSettings.n8nImportSecret)) {
+  if (existing && (!rawSettings.n8nWebhookSecret || !rawSettings.n8nDispatchSecret || !rawSettings.n8nEnrollSecret || !rawSettings.n8nImportSecret || !rawSettings.n8nBlastSecret)) {
     try {
       const stored = JSON.parse(existing.settings) as Record<string, unknown>
       if (!rawSettings.n8nWebhookSecret && typeof stored.n8nWebhookSecret === 'string' && stored.n8nWebhookSecret) {
@@ -217,6 +229,9 @@ export async function PUT(request: Request) {
       }
       if (!rawSettings.n8nImportSecret && typeof stored.n8nImportSecret === 'string' && stored.n8nImportSecret) {
         rawSettings.n8nImportSecret = stored.n8nImportSecret
+      }
+      if (!rawSettings.n8nBlastSecret && typeof stored.n8nBlastSecret === 'string' && stored.n8nBlastSecret) {
+        rawSettings.n8nBlastSecret = stored.n8nBlastSecret
       }
     } catch { /* corrupt stored JSON — skip merge */ }
   }
@@ -267,9 +282,11 @@ export async function PUT(request: Request) {
       n8nEnrollSecret: _es,
       n8nImportUrl: _iu,
       n8nImportSecret: _is,
+      n8nBlastUrl: _bu,
+      n8nBlastSecret: _bs,
       ...settingsPayload
     } = rawSettings
-    void _u; void _s; void _du; void _ds; void _eu; void _es; void _iu; void _is
+    void _u; void _s; void _du; void _ds; void _eu; void _es; void _iu; void _is; void _bu; void _bs
     const payload = {
       tenantId,
       status,

--- a/app/api/sdr/templates/route.ts
+++ b/app/api/sdr/templates/route.ts
@@ -1,0 +1,92 @@
+// GET /api/sdr/templates
+//
+// Lista os templates aprovados (meta_templates_whatsapp) no Supabase para o modal
+// de disparo escolher. Connection string obtida do data_source do tenant
+// (providerKey='supabase-n8n'), decifrada em runtime — nunca exposta ao cliente.
+//
+// SOMENTE LEITURA: apenas SELECT. Nunca escreve no Supabase.
+//
+// Response: { items: { nome_template: string, preview: string, fase_envio: string|null }[] }
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { dataSources } from '@/lib/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { decrypt } from '@/lib/crypto'
+import { assertEntitlement } from '@/lib/entitlements'
+import { Client } from 'pg'
+
+const PROVIDER_KEY = 'supabase-n8n'
+
+interface TemplateRow {
+  nome_template:     string
+  mensagem_template: string | null
+  fase_envio:        string | null
+  rank_disparo:      number | null
+}
+
+export async function GET() {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { tenantId } = session.user
+  const denied = await assertEntitlement(tenantId, 'sdr.parametros')
+  if (denied) return denied
+
+  // Load Supabase connection string from the tenant's data source
+  const row = await db
+    .select()
+    .from(dataSources)
+    .where(and(
+      eq(dataSources.tenantId, tenantId),
+      eq(dataSources.providerKey, PROVIDER_KEY),
+    ))
+    .then(r => r[0])
+
+  if (!row?.configEnc) {
+    return NextResponse.json({ error: 'fonte_sdr_nao_configurada' }, { status: 400 })
+  }
+
+  let connectionString: string
+  try {
+    const cfg = JSON.parse(decrypt(row.configEnc)) as { connectionString?: string }
+    if (!cfg.connectionString) throw new Error('connectionString ausente')
+    connectionString = cfg.connectionString
+  } catch (err) {
+    return NextResponse.json(
+      { error: 'config_invalid', message: (err as Error).message },
+      { status: 500 },
+    )
+  }
+
+  const client = new Client({ connectionString })
+  try {
+    await client.connect()
+
+    // SELECT only — never writes
+    const res = await client.query<TemplateRow>(
+      `SELECT nome_template, mensagem_template, fase_envio, rank_disparo
+         FROM meta_templates_whatsapp
+        WHERE nome_template IS NOT NULL
+          AND COALESCE(mensagem_template, '') <> ''
+        ORDER BY rank_disparo NULLS LAST, nome_template`,
+    )
+
+    const items = res.rows.map(r => ({
+      nome_template: r.nome_template,
+      preview:       r.mensagem_template ?? '',
+      fase_envio:    r.fase_envio,
+    }))
+
+    return NextResponse.json({ items })
+  } catch (err) {
+    console.error('[sdr templates GET]', err)
+    return NextResponse.json(
+      { error: 'db_error', message: (err as Error).message },
+      { status: 502 },
+    )
+  } finally {
+    await client.end().catch(() => {})
+  }
+}


### PR DESCRIPTION
- app/api/sdr/leads/blast: disparo em massa de leads.
- app/api/sdr/templates: gestão de templates.
- settings/route.ts: n8nImportUrl/n8nBlastUrl (+ secrets) — validação anti-SSRF,
  strip do payload de write-back e preservação de secret, igual aos demais.
- Parâmetros + página Leads: UI de import/blast.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
