### PR TITLE
feat: blast pós-import inclui contatos já cadastrados

### DIFF
--- a/app/(app)/sdr-ia/leads/page.tsx
+++ b/app/(app)/sdr-ia/leads/page.tsx
@@ -28,8 +28,9 @@ interface ImportResult {
   ignorados?:   { total: number; amostra: Array<{ linha: number; motivo: string }> }
   duplicados?:  { total: number; amostra: Array<{ linha: number; telefone: string }> }
   n8nStatus?:   number
-  leadIds?:     string[]
-  error?:       string
+  leadIds?:        string[]
+  existingLeadIds?: string[]
+  error?:          string
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -263,7 +264,11 @@ export default function LeadsPage() {
   }
 
   async function runBlast() {
-    const ids = importResult?.leadIds ?? []
+    // Alvo do blast = novos + já existentes (deduplicado)
+    const ids = Array.from(new Set([
+      ...(importResult?.leadIds ?? []),
+      ...(importResult?.existingLeadIds ?? []),
+    ]))
     if (ids.length === 0 || !selectedTemplate) return
     setBlasting(true)
     setBlastResult(null)
@@ -304,10 +309,12 @@ export default function LeadsPage() {
         setImportResult(json)
         setPage(1)
         setFetchSeq(s => s + 1)
-        // Open campaign modal when n8n returned IDs for the new leads
-        if ((json.leadIds?.length ?? 0) > 0) {
+        // Open modal when there are targets: novos OU já existentes (casaram na dedup)
+        const targetCount = (json.leadIds?.length ?? 0) + (json.existingLeadIds?.length ?? 0)
+        if (targetCount > 0) {
           setCampaignEnrolling(false)
           setCampaignEnrollResult(null)
+          setBlastMode(false)
           setShowCampaignModal(true)
         }
       }
@@ -328,6 +335,14 @@ export default function LeadsPage() {
   const n8nFalhou = (importResult?.importados ?? 0) > 0
     && typeof importResult?.n8nStatus === 'number'
     && (importResult.n8nStatus < 200 || importResult.n8nStatus >= 300)
+
+  // Alvos pós-import: novos (vieram do n8n) + já existentes (casaram na dedup)
+  const novosCount      = importResult?.leadIds?.length ?? 0
+  const existentesCount = importResult?.existingLeadIds?.length ?? 0
+  const blastTotal      = new Set([
+    ...(importResult?.leadIds ?? []),
+    ...(importResult?.existingLeadIds ?? []),
+  ]).size
 
   return (
     <div>
@@ -733,14 +748,22 @@ export default function LeadsPage() {
                   fontSize: 18, fontWeight: 800, color: 'var(--black)',
                   letterSpacing: '-0.01em', marginBottom: 10,
                 }}>
-                  {importResult?.importados} lead{importResult?.importados !== 1 ? 's' : ''} importados — o que fazer?
+                  {[
+                    novosCount > 0 ? `${novosCount} novo${novosCount !== 1 ? 's' : ''}` : null,
+                    existentesCount > 0 ? `${existentesCount} já na base` : null,
+                  ].filter(Boolean).join(' · ')} — o que fazer?
                 </div>
 
                 {/* Description */}
                 <div style={{ fontSize: 13, color: 'var(--gray)', lineHeight: 1.65, marginBottom: 24 }}>
-                  <strong>Adicionar à campanha</strong> coloca esses leads na fila de disparo SDR
-                  (Template 1, agendado). <strong>Disparar mensagens</strong> envia um template
-                  aprovado agora para toda a lista.
+                  <strong>Disparar mensagens</strong> envia um template aprovado agora para toda a
+                  lista ({blastTotal} contato{blastTotal !== 1 ? 's' : ''}, novos + já existentes).
+                  {novosCount > 0 && (
+                    <> <strong>Adicionar à campanha</strong> coloca só os {novosCount} novo{novosCount !== 1 ? 's' : ''} na fila do drip SDR (Template 1).</>
+                  )}
+                  {novosCount === 0 && (
+                    <> Todos os contatos já estão na base — só o disparo está disponível.</>
+                  )}
                 </div>
 
                 {/* Loading */}
@@ -801,20 +824,22 @@ export default function LeadsPage() {
                       >
                         Disparar mensagens agora
                       </button>
-                      <button
-                        onClick={enrollImported}
-                        disabled={campaignEnrolling}
-                        style={{
-                          padding: '10px 22px', borderRadius: 99, fontFamily: 'inherit',
-                          fontSize: 13, fontWeight: 800, border: 'none',
-                          background: campaignEnrolling ? 'var(--gray3)' : 'var(--primary)',
-                          color: campaignEnrolling ? 'var(--gray2)' : 'var(--white)',
-                          cursor: campaignEnrolling ? 'not-allowed' : 'pointer',
-                          opacity: campaignEnrolling ? 0.7 : 1,
-                        }}
-                      >
-                        Adicionar à campanha
-                      </button>
+                      {novosCount > 0 && (
+                        <button
+                          onClick={enrollImported}
+                          disabled={campaignEnrolling}
+                          style={{
+                            padding: '10px 22px', borderRadius: 99, fontFamily: 'inherit',
+                            fontSize: 13, fontWeight: 800, border: 'none',
+                            background: campaignEnrolling ? 'var(--gray3)' : 'var(--primary)',
+                            color: campaignEnrolling ? 'var(--gray2)' : 'var(--white)',
+                            cursor: campaignEnrolling ? 'not-allowed' : 'pointer',
+                            opacity: campaignEnrolling ? 0.7 : 1,
+                          }}
+                        >
+                          Adicionar à campanha
+                        </button>
+                      )}
                     </>
                   )}
                 </div>
@@ -826,7 +851,7 @@ export default function LeadsPage() {
                   fontSize: 18, fontWeight: 800, color: 'var(--black)',
                   letterSpacing: '-0.01em', marginBottom: 10,
                 }}>
-                  Disparar para {importResult?.leadIds?.length ?? 0} contato{(importResult?.leadIds?.length ?? 0) !== 1 ? 's' : ''}
+                  Disparar para {blastTotal} contato{blastTotal !== 1 ? 's' : ''}
                 </div>
                 <div style={{ fontSize: 13, color: 'var(--gray)', lineHeight: 1.65, marginBottom: 18 }}>
                   Envio real de WhatsApp usando um <strong>template aprovado</strong> para toda a

--- a/app/api/sdr/leads/import/route.ts
+++ b/app/api/sdr/leads/import/route.ts
@@ -218,7 +218,8 @@ export async function POST(request: Request) {
   // ── Dedup against Supabase (SOMENTE SELECT — nunca escreve) ──────────────────
   // Uses phoneKey on both columns to match across heterogeneous formats:
   // DB phone may be raw/masked; phone_adjusted is digits-only without '+'.
-  const existingKeys = new Set<string>()
+  const existingKeys    = new Set<string>()
+  const existingIdByKey = new Map<string, string>()  // phoneKey → id do lead já cadastrado (1ª ocorrência vence)
 
   if (candidatos.length > 0) {
     const dsRow = await db
@@ -240,16 +241,16 @@ export async function POST(request: Request) {
 
           // Fetch broadly — exact-string match is unreliable across formats;
           // phoneKey normalizes both sides in the app. SELECT only — never writes.
-          const res = await pgClient.query<{ phone: string | null; phone_adjusted: string | null }>(
-            `SELECT phone, phone_adjusted
+          const res = await pgClient.query<{ id: string; phone: string | null; phone_adjusted: string | null }>(
+            `SELECT id, phone, phone_adjusted
                FROM leads
               WHERE phone IS NOT NULL OR phone_adjusted IS NOT NULL`,
           )
           for (const r of res.rows) {
             const k1 = phoneKey(r.phone ?? '')
             const k2 = phoneKey(r.phone_adjusted ?? '')
-            if (k1) existingKeys.add(k1)
-            if (k2) existingKeys.add(k2)
+            if (k1) { existingKeys.add(k1); if (!existingIdByKey.has(k1)) existingIdByKey.set(k1, r.id) }
+            if (k2) { existingKeys.add(k2); if (!existingIdByKey.has(k2)) existingIdByKey.set(k2, r.id) }
           }
         }
       } catch (err) {
@@ -263,9 +264,12 @@ export async function POST(request: Request) {
 
   // Partition candidatos into novos (new) vs supabase-duplicates
   const novos: LeadEntry[] = []
+  const existingLeadIdSet = new Set<string>()  // ids dos leads JÁ cadastrados que casaram na dedup
   for (const c of candidatos) {
     if (existingKeys.has(c.key)) {
       duplicados.push({ linha: c.linha, telefone: c.phone })
+      const existingId = existingIdByKey.get(c.key)
+      if (existingId) existingLeadIdSet.add(existingId)
     } else {
       novos.push({ name: c.name, phone: c.phone, company: c.company, source: c.source, status: c.status })
     }
@@ -318,5 +322,6 @@ export async function POST(request: Request) {
     },
     n8nStatus,
     leadIds,
+    existingLeadIds: Array.from(existingLeadIdSet),
   })
 }


### PR DESCRIPTION
Estende o disparo direto (blast) pós-import para alcançar também os contatos da lista que **já existem na base** (antes ia só para os recém-criados).

## Mudanças
- **import** (`/api/sdr/leads/import`): além de `leadIds` (novos), retorna `existingLeadIds` — os UUIDs dos leads que casaram na deduplicação contra o Supabase. Nada é inserido para os duplicados; só SELECT.
- **leads** (`/sdr-ia/leads`): o disparo alcança a **união** novos + já existentes; o modal abre mesmo quando a lista é 100% já cadastrada; "Adicionar à campanha" continua só com os novos (oculto quando não há novos).

## Notas
- App não escreve no Supabase nem envia WhatsApp — envio é do n8n (fluxo de blast).
- `npx tsc --noEmit` limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)