### PR TITLE
fix: garante 9º dígito de celular BR no disparo (blast)

### DIFF
--- a/app/api/sdr/leads/blast/route.ts
+++ b/app/api/sdr/leads/blast/route.ts
@@ -43,6 +43,18 @@ function toE164(phone: string | null, phoneAdjusted: string | null): string | nu
   return E164_RE.test(e164) ? e164 : null
 }
 
+// Ensure BR mobile numbers have the 9th digit (DDD(2) + 9 + 8 digits = 11 national digits).
+// Old leads may be stored without it (10 national digits). Landlines (1st digit 2-5) are
+// left untouched. Non-BR numbers are returned as-is.
+function ensureBr9(e164: string): string {
+  if (!e164.startsWith('+55')) return e164
+  const national = e164.slice(3) // remove '+55'
+  if (national.length !== 10) return e164
+  const firstDigit = national[2] // 1st digit after DDD
+  if (firstDigit < '6') return e164 // landline (2-5) or already impossible — skip
+  return '+55' + national.slice(0, 2) + '9' + national.slice(2)
+}
+
 export async function POST(request: Request) {
   const session = await auth()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -145,7 +157,7 @@ export async function POST(request: Request) {
 
     recipients = []
     for (const r of leadsRes.rows) {
-      const phone = toE164(r.phone, r.phone_adjusted)
+      const phone = ensureBr9(toE164(r.phone, r.phone_adjusted) ?? '')
       if (!phone) continue  // sem telefone válido → skip
       const first_name = (r.name ?? '').trim().split(/\s+/)[0] ?? ''
       recipients.push({ phone, first_name })


### PR DESCRIPTION
## Problema
Leads antigos guardam o telefone **sem o 9º dígito** (ex.: `+553195526168`). O WhatsApp BR não entrega para celular sem o 9, e o YCloud **aceita** (HTTP 200) sem erro — então o retry "Flip do 9" do n8n não dispara. Resultado: número sem o 9 não recebe (só recebiam os já gravados com o 9).

## Correção
`ensureBr9` na rota de blast insere o 9 para celular BR (nacional de 10 dígitos cujo 1º dígito do número é 6-9), antes de enviar ao n8n. Fixos (2-5) e números já com 11 dígitos ficam inalterados; não-BR inalterados.

- `+553195526168 → +5531995526168`
- `+553182440323 → +5531982440323`
- `+5554981204124` → inalterado

`npx tsc --noEmit` limpo. O Flip-9 do n8n permanece como rede de segurança.

🤖 Generated with [Claude Code](https://claude.com/claude-code)