### PR TITLE
feat: disparo para todos com nome do Excel e fallback 'tudo bem'

### DIFF
--- a/app/(app)/sdr-ia/leads/page.tsx
+++ b/app/(app)/sdr-ia/leads/page.tsx
@@ -30,6 +30,8 @@ interface ImportResult {
   n8nStatus?:   number
   leadIds?:        string[]
   existingLeadIds?: string[]
+  names?:          Record<string, string>
+  semNome?:        number
   error?:          string
 }
 
@@ -104,7 +106,8 @@ export default function LeadsPage() {
   const [blastTplLoading,  setBlastTplLoading]  = useState(false)
   const [blastTplError,    setBlastTplError]    = useState<string | null>(null)
   const [selectedTemplate, setSelectedTemplate] = useState('')
-  const [blasting,         setBlasting]         = useState(false)
+  const [blasting,             setBlasting]             = useState(false)
+  const [blastPendingConfirm,  setBlastPendingConfirm]  = useState(false)
   const [blastResult,      setBlastResult]      = useState<{
     ok: boolean; started?: number; totalSolicitado?: number; skipped?: number; error?: string
   } | null>(null)
@@ -242,6 +245,7 @@ export default function LeadsPage() {
     setBlastMode(false)
     setBlastResult(null)
     setSelectedTemplate('')
+    setBlastPendingConfirm(false)
   }
 
   async function openBlast() {
@@ -276,7 +280,7 @@ export default function LeadsPage() {
       const res = await fetch('/api/sdr/leads/blast', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ leadIds: ids, template: selectedTemplate }),
+        body: JSON.stringify({ leadIds: ids, template: selectedTemplate, names: importResult?.names ?? {} }),
       })
       const data = await res.json() as { ok: boolean; started?: number; totalSolicitado?: number; skipped?: number; error?: string }
       if (res.ok && data.ok) {
@@ -870,7 +874,7 @@ export default function LeadsPage() {
                   </div>
                 )}
 
-                {blastTemplates && !blastResult && (
+                {blastTemplates && !blastResult && !blastPendingConfirm && (
                   <div style={{ marginBottom: 18 }}>
                     <select
                       value={selectedTemplate}
@@ -901,6 +905,22 @@ export default function LeadsPage() {
                   </div>
                 )}
 
+                {blastPendingConfirm && !blastResult && (
+                  <div style={{
+                    marginBottom: 18, padding: '12px 16px', borderRadius: 10,
+                    background: 'rgba(245,158,11,0.08)', border: '1px solid rgba(245,158,11,0.35)',
+                  }}>
+                    <div style={{ fontSize: 13, fontWeight: 700, color: '#92400e', marginBottom: 4 }}>
+                      Confirmar disparo
+                    </div>
+                    <div style={{ fontSize: 13, color: '#78350f', lineHeight: 1.6 }}>
+                      {(importResult?.semNome ?? 0)} contato{(importResult?.semNome ?? 0) !== 1 ? 's' : ''} sem nome serão
+                      enviados com a saudação padrão <strong>&ldquo;tudo bem&rdquo;</strong>.
+                      Deseja continuar?
+                    </div>
+                  </div>
+                )}
+
                 {blasting && (
                   <div style={{ fontSize: 13, color: 'var(--gray2)', marginBottom: 18 }}>Disparando...</div>
                 )}
@@ -925,34 +945,74 @@ export default function LeadsPage() {
 
                 {/* Actions */}
                 <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', flexWrap: 'wrap' }}>
-                  <button
-                    onClick={() => { if (blastResult) { closeCampaignModal() } else { setBlastMode(false) } }}
-                    disabled={blasting}
-                    style={{
-                      padding: '10px 20px', borderRadius: 99, fontFamily: 'inherit',
-                      fontSize: 13, fontWeight: 700,
-                      border: '1px solid var(--gray3)', background: 'transparent',
-                      color: 'var(--gray)', cursor: blasting ? 'not-allowed' : 'pointer',
-                      opacity: blasting ? 0.5 : 1,
-                    }}
-                  >
-                    {blastResult ? 'Fechar' : 'Voltar'}
-                  </button>
-                  {!blastResult && (
-                    <button
-                      onClick={runBlast}
-                      disabled={blasting || !selectedTemplate}
-                      style={{
-                        padding: '10px 22px', borderRadius: 99, fontFamily: 'inherit',
-                        fontSize: 13, fontWeight: 800, border: 'none',
-                        background: (blasting || !selectedTemplate) ? 'var(--gray3)' : 'var(--primary)',
-                        color: (blasting || !selectedTemplate) ? 'var(--gray2)' : 'var(--white)',
-                        cursor: (blasting || !selectedTemplate) ? 'not-allowed' : 'pointer',
-                        opacity: (blasting || !selectedTemplate) ? 0.7 : 1,
-                      }}
-                    >
-                      Disparar
-                    </button>
+                  {blastPendingConfirm && !blastResult ? (
+                    <>
+                      <button
+                        onClick={() => setBlastPendingConfirm(false)}
+                        disabled={blasting}
+                        style={{
+                          padding: '10px 20px', borderRadius: 99, fontFamily: 'inherit',
+                          fontSize: 13, fontWeight: 700,
+                          border: '1px solid var(--gray3)', background: 'transparent',
+                          color: 'var(--gray)', cursor: blasting ? 'not-allowed' : 'pointer',
+                          opacity: blasting ? 0.5 : 1,
+                        }}
+                      >
+                        Cancelar
+                      </button>
+                      <button
+                        onClick={runBlast}
+                        disabled={blasting}
+                        style={{
+                          padding: '10px 22px', borderRadius: 99, fontFamily: 'inherit',
+                          fontSize: 13, fontWeight: 800, border: 'none',
+                          background: blasting ? 'var(--gray3)' : 'var(--primary)',
+                          color: blasting ? 'var(--gray2)' : 'var(--white)',
+                          cursor: blasting ? 'not-allowed' : 'pointer',
+                          opacity: blasting ? 0.7 : 1,
+                        }}
+                      >
+                        Confirmar disparo
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <button
+                        onClick={() => {
+                          if (blastResult) { closeCampaignModal() }
+                          else { setBlastMode(false); setBlastPendingConfirm(false) }
+                        }}
+                        disabled={blasting}
+                        style={{
+                          padding: '10px 20px', borderRadius: 99, fontFamily: 'inherit',
+                          fontSize: 13, fontWeight: 700,
+                          border: '1px solid var(--gray3)', background: 'transparent',
+                          color: 'var(--gray)', cursor: blasting ? 'not-allowed' : 'pointer',
+                          opacity: blasting ? 0.5 : 1,
+                        }}
+                      >
+                        {blastResult ? 'Fechar' : 'Voltar'}
+                      </button>
+                      {!blastResult && (
+                        <button
+                          onClick={() => {
+                            if ((importResult?.semNome ?? 0) > 0) { setBlastPendingConfirm(true) }
+                            else { void runBlast() }
+                          }}
+                          disabled={blasting || !selectedTemplate}
+                          style={{
+                            padding: '10px 22px', borderRadius: 99, fontFamily: 'inherit',
+                            fontSize: 13, fontWeight: 800, border: 'none',
+                            background: (blasting || !selectedTemplate) ? 'var(--gray3)' : 'var(--primary)',
+                            color: (blasting || !selectedTemplate) ? 'var(--gray2)' : 'var(--white)',
+                            cursor: (blasting || !selectedTemplate) ? 'not-allowed' : 'pointer',
+                            opacity: (blasting || !selectedTemplate) ? 0.7 : 1,
+                          }}
+                        >
+                          Disparar
+                        </button>
+                      )}
+                    </>
                   )}
                 </div>
               </>

--- a/app/api/sdr/leads/blast/route.ts
+++ b/app/api/sdr/leads/blast/route.ts
@@ -20,9 +20,10 @@ import { decrypt } from '@/lib/crypto'
 import { assertEntitlement } from '@/lib/entitlements'
 import { Client } from 'pg'
 
-const PROVIDER_KEY = 'supabase-n8n'
-const SOURCE       = 'sdr-n8n'
-const MAX_LEADS    = 1000
+const PROVIDER_KEY      = 'supabase-n8n'
+const SOURCE            = 'sdr-n8n'
+const MAX_LEADS         = 1000
+const DEFAULT_FIRST_NAME = 'tudo bem'
 const UUID_RE      = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 const E164_RE      = /^\+[1-9]\d{6,14}$/
 
@@ -63,7 +64,7 @@ export async function POST(request: Request) {
   const denied = await assertEntitlement(tenantId, 'sdr.parametros')
   if (denied) return denied
 
-  let body: { leadIds?: unknown; template?: unknown }
+  let body: { leadIds?: unknown; template?: unknown; names?: unknown }
   try { body = await request.json() } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
   }
@@ -85,6 +86,11 @@ export async function POST(request: Request) {
   if (leadIds.length === 0) {
     return NextResponse.json({ error: 'nenhum leadId válido (UUID esperado)' }, { status: 400 })
   }
+
+  const names: Record<string, string> =
+    body.names !== null && typeof body.names === 'object' && !Array.isArray(body.names)
+      ? (body.names as Record<string, string>)
+      : {}
 
   // ── Load n8nBlastUrl + secret from campaign settings ──────────────────────────
   const [csRow] = await db
@@ -159,7 +165,8 @@ export async function POST(request: Request) {
     for (const r of leadsRes.rows) {
       const phone = ensureBr9(toE164(r.phone, r.phone_adjusted) ?? '')
       if (!phone) continue  // sem telefone válido → skip
-      const first_name = (r.name ?? '').trim().split(/\s+/)[0] ?? ''
+      const dbFirst = String(r.name ?? '').trim().split(/\s+/)[0] ?? ''
+      const first_name = dbFirst || names[r.id] || DEFAULT_FIRST_NAME
       recipients.push({ phone, first_name })
     }
   } catch (err) {

--- a/app/api/sdr/leads/import/route.ts
+++ b/app/api/sdr/leads/import/route.ts
@@ -82,6 +82,10 @@ function phoneKey(raw: string): string | null {
   return national.length >= 10 ? national : null
 }
 
+function firstWord(s: unknown): string {
+  return String(s ?? '').trim().split(/\s+/)[0] ?? ''
+}
+
 export async function POST(request: Request) {
   const session = await auth()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -186,11 +190,6 @@ export async function POST(request: Request) {
     const source  = row.source  || 'import'
     const status  = row.status  || 'novo'
 
-    if (!name) {
-      ignorados.push({ linha, motivo: 'nome ausente' })
-      continue
-    }
-
     // E.164 required for the n8n payload
     const normalized = normalizePhone(phone)
     if (!normalized) {
@@ -218,8 +217,7 @@ export async function POST(request: Request) {
   // ── Dedup against Supabase (SOMENTE SELECT — nunca escreve) ──────────────────
   // Uses phoneKey on both columns to match across heterogeneous formats:
   // DB phone may be raw/masked; phone_adjusted is digits-only without '+'.
-  const existingKeys    = new Set<string>()
-  const existingIdByKey = new Map<string, string>()  // phoneKey → id do lead já cadastrado (1ª ocorrência vence)
+  const existingByKey = new Map<string, { id: string; name: string | null }>()  // phoneKey → { id, name } (1ª ocorrência vence)
 
   if (candidatos.length > 0) {
     const dsRow = await db
@@ -241,16 +239,17 @@ export async function POST(request: Request) {
 
           // Fetch broadly — exact-string match is unreliable across formats;
           // phoneKey normalizes both sides in the app. SELECT only — never writes.
-          const res = await pgClient.query<{ id: string; phone: string | null; phone_adjusted: string | null }>(
-            `SELECT id, phone, phone_adjusted
+          const res = await pgClient.query<{ id: string; name: string | null; phone: string | null; phone_adjusted: string | null }>(
+            `SELECT id, name, phone, phone_adjusted
                FROM leads
               WHERE phone IS NOT NULL OR phone_adjusted IS NOT NULL`,
           )
           for (const r of res.rows) {
             const k1 = phoneKey(r.phone ?? '')
             const k2 = phoneKey(r.phone_adjusted ?? '')
-            if (k1) { existingKeys.add(k1); if (!existingIdByKey.has(k1)) existingIdByKey.set(k1, r.id) }
-            if (k2) { existingKeys.add(k2); if (!existingIdByKey.has(k2)) existingIdByKey.set(k2, r.id) }
+            const entry = { id: r.id, name: r.name }
+            if (k1 && !existingByKey.has(k1)) existingByKey.set(k1, entry)
+            if (k2 && !existingByKey.has(k2)) existingByKey.set(k2, entry)
           }
         }
       } catch (err) {
@@ -268,19 +267,25 @@ export async function POST(request: Request) {
   const updates: UpdateEntry[] = []
   const existingLeadIdSet = new Set<string>()  // ids dos leads JÁ cadastrados que casaram na dedup
   const updatedIdSet = new Set<string>()        // dedup ids within updates
+  const names: Record<string, string> = {}      // leadId → 1º nome do Excel (só duplicados com nome não-vazio)
+  let semNome = 0                               // destinatários que ficarão sem nome em lugar nenhum
   for (const c of candidatos) {
-    if (existingKeys.has(c.key)) {
+    if (existingByKey.has(c.key)) {
       duplicados.push({ linha: c.linha, telefone: c.phone })
-      const existingId = existingIdByKey.get(c.key)
-      if (existingId) {
-        existingLeadIdSet.add(existingId)
-        if (!updatedIdSet.has(existingId)) {
-          updatedIdSet.add(existingId)
-          updates.push({ id: existingId, name: c.name, company: c.company, source: c.source, status: c.status })
-        }
+      const existing = existingByKey.get(c.key)!
+      existingLeadIdSet.add(existing.id)
+      if (!updatedIdSet.has(existing.id)) {
+        updatedIdSet.add(existing.id)
+        updates.push({ id: existing.id, name: c.name, company: c.company, source: c.source, status: c.status })
       }
+      if (c.name.trim()) {
+        names[existing.id] = firstWord(c.name)
+      }
+      const dbName = (existing.name ?? '').trim()
+      if (!dbName && !c.name.trim()) semNome++
     } else {
       novos.push({ name: c.name, phone: c.phone, company: c.company, source: c.source, status: c.status })
+      if (!c.name.trim()) semNome++
     }
   }
 
@@ -333,5 +338,7 @@ export async function POST(request: Request) {
     n8nStatus,
     leadIds,
     existingLeadIds: Array.from(existingLeadIdSet),
+    names,
+    semNome,
   })
 }


### PR DESCRIPTION
Garante que **todo contato da lista importada receba** o disparo, com o nome correto, sem depender do timing do UPDATE assíncrono.

## Mudanças
- **import**: para de descartar linhas sem nome (telefone válido entra e dispara). Devolve `names` (id→1º nome do Excel dos duplicados) e `semNome` (qtd que ficará sem nome).
- **blast**: `first_name` = nome do banco → nome do Excel (override `names`) → `'tudo bem'`. Nunca envia parâmetro vazio (corrige o erro 131008 do WhatsApp).
- **leads (modal)**: passa `names` ao blast; se `semNome > 0`, avisa e exige confirmação antes de disparar com a saudação padrão.

Sem mudança no n8n. App não escreve no Supabase. `npx tsc --noEmit` limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)