### PR TITLE
feat: disparo (blast) registra mensagem em Conversas

### DIFF
--- a/app/(app)/sdr-ia/leads/page.tsx
+++ b/app/(app)/sdr-ia/leads/page.tsx
@@ -274,13 +274,15 @@ export default function LeadsPage() {
       ...(importResult?.existingLeadIds ?? []),
     ]))
     if (ids.length === 0 || !selectedTemplate) return
+    const tpl = blastTemplates?.find(t => t.nome_template === selectedTemplate)
+    const templateBody = tpl?.preview ?? ''
     setBlasting(true)
     setBlastResult(null)
     try {
       const res = await fetch('/api/sdr/leads/blast', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ leadIds: ids, template: selectedTemplate, names: importResult?.names ?? {} }),
+        body: JSON.stringify({ leadIds: ids, template: selectedTemplate, names: importResult?.names ?? {}, templateBody }),
       })
       const data = await res.json() as { ok: boolean; started?: number; totalSolicitado?: number; skipped?: number; error?: string }
       if (res.ok && data.ok) {

--- a/app/api/sdr/leads/blast/route.ts
+++ b/app/api/sdr/leads/blast/route.ts
@@ -8,7 +8,7 @@
 // REGRA CRÍTICA: a app NUNCA escreve no Supabase — apenas LÊ (leads + remetente).
 // O envio é responsabilidade do n8n.
 //
-// Body:     { leadIds: string[], template: string }
+// Body:     { leadIds: string[], template: string, templateBody?: string, names?: Record<string,string> }
 // Response: { ok, started, totalSolicitado, skipped }
 
 import { NextResponse } from 'next/server'
@@ -44,6 +44,11 @@ function toE164(phone: string | null, phoneAdjusted: string | null): string | nu
   return E164_RE.test(e164) ? e164 : null
 }
 
+// Render template body replacing all {{variable}} placeholders with firstName.
+function renderMessage(templateBody: string, firstName: string): string {
+  return String(templateBody ?? '').replace(/\{\{\s*[\w.]+\s*\}\}/g, firstName)
+}
+
 // Ensure BR mobile numbers have the 9th digit (DDD(2) + 9 + 8 digits = 11 national digits).
 // Old leads may be stored without it (10 national digits). Landlines (1st digit 2-5) are
 // left untouched. Non-BR numbers are returned as-is.
@@ -64,12 +69,13 @@ export async function POST(request: Request) {
   const denied = await assertEntitlement(tenantId, 'sdr.parametros')
   if (denied) return denied
 
-  let body: { leadIds?: unknown; template?: unknown; names?: unknown }
+  let body: { leadIds?: unknown; template?: unknown; names?: unknown; templateBody?: unknown }
   try { body = await request.json() } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
   }
 
-  const template = typeof body.template === 'string' ? body.template.trim() : ''
+  const template     = typeof body.template     === 'string' ? body.template.trim()     : ''
+  const templateBody = typeof body.templateBody === 'string' ? body.templateBody        : ''
   if (!template) {
     return NextResponse.json({ error: 'template é obrigatório' }, { status: 400 })
   }
@@ -141,7 +147,7 @@ export async function POST(request: Request) {
 
   // ── Resolve remetente + recipients (SOMENTE SELECT — nunca escreve) ───────────
   const client = new Client({ connectionString })
-  let recipients: { phone: string; first_name: string }[]
+  let recipients: { phone: string; first_name: string; message: string; session_id: string }[]
   let remetente: string
 
   try {
@@ -165,9 +171,12 @@ export async function POST(request: Request) {
     for (const r of leadsRes.rows) {
       const phone = ensureBr9(toE164(r.phone, r.phone_adjusted) ?? '')
       if (!phone) continue  // sem telefone válido → skip
-      const dbFirst = String(r.name ?? '').trim().split(/\s+/)[0] ?? ''
+      const dbFirst    = String(r.name ?? '').trim().split(/\s+/)[0] ?? ''
       const first_name = dbFirst || names[r.id] || DEFAULT_FIRST_NAME
-      recipients.push({ phone, first_name })
+      const message    = renderMessage(templateBody, first_name)
+      const rawSession = (r.phone_adjusted ?? r.phone ?? '').replace(/\D/g, '')
+      const session_id = rawSession || phone.replace(/\D/g, '')
+      recipients.push({ phone, first_name, message, session_id })
     }
   } catch (err) {
     console.error('[sdr blast resolve]', err)


### PR DESCRIPTION
Faz as mensagens do disparo (blast) **aparecerem em Conversas** — antes só iam ao WhatsApp e não eram registradas.

## Mudanças (app)
- **blast route**: cada destinatário passa a carregar `message` (corpo do template renderizado com o nome) e `session_id` (dígitos do `phone_adjusted`, formato `553195526168`, igual ao que o `n8n_chat_histories` usa — garante a thread certa).
- **modal**: passa `templateBody` (preview do template selecionado) ao blast.

## n8n (separado, já entregue em Downloads)
O fluxo `300-leads-blast` ganhou o nó **Log Chat History** que grava em `n8n_chat_histories` no formato flat `{type:'ai', content}` (validado por leitura: é o formato que o provider lê e que a IA do n8n usa). Precisa re-importar + credencial SheepCrew Postgres + ativar.

`npx tsc --noEmit` limpo. App não escreve no Supabase — quem grava é o n8n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)