### PR TITLE
feat: sincronização de conversas sob demanda

### DIFF
--- a/app/(app)/sdr-ia/conversas/page.tsx
+++ b/app/(app)/sdr-ia/conversas/page.tsx
@@ -288,6 +288,11 @@ export default function ConversasPage() {
   const [sending,     setSending]     = useState(false)
   const [sendError,   setSendError]   = useState<string | null>(null)
 
+  // Sync on demand
+  const [syncing,      setSyncing]      = useState(false)
+  const [syncFeedback, setSyncFeedback] = useState<'success' | 'error' | null>(null)
+  const [syncEpoch,    setSyncEpoch]    = useState(0)
+
   // Search
   const [searchRaw, setSearchRaw] = useState('')
   const [search,    setSearch]    = useState('')
@@ -319,7 +324,7 @@ export default function ConversasPage() {
       })
       .catch(() => setSessError(true))
       .finally(() => setSessLoading(false))
-  }, [sessPage])
+  }, [sessPage, syncEpoch])
 
   // ── Smart auto-scroll ───────────────────────────────────────────────────────
   // When a conversation is opened/switched, loadThread() sets scrollToBottomOnLoadRef
@@ -420,6 +425,24 @@ export default function ConversasPage() {
       document.removeEventListener('visibilitychange', onVisibilityChange)
     }
   }, [])  // intentionally empty — reads live state through refs
+
+  // ── Sync on demand ──────────────────────────────────────────────────────────
+  async function syncNow() {
+    if (syncing) return
+    setSyncing(true)
+    setSyncFeedback(null)
+    try {
+      const res = await fetch('/api/sdr/sync', { method: 'POST' })
+      if (!res.ok) throw new Error()
+      setSyncFeedback('success')
+      setSyncEpoch(e => e + 1)
+    } catch {
+      setSyncFeedback('error')
+    } finally {
+      setSyncing(false)
+      setTimeout(() => setSyncFeedback(null), 3000)
+    }
+  }
 
   // ── Open a session ──────────────────────────────────────────────────────────
   function loadThread(sessionId: string) {
@@ -545,11 +568,36 @@ export default function ConversasPage() {
         display: 'flex', flexDirection: 'column',
       }}>
         <div style={{
-          padding: '12px 16px', borderBottom: '1px solid var(--gray3)',
-          fontSize: 11, fontWeight: 800, textTransform: 'uppercase',
-          letterSpacing: '0.08em', color: 'var(--gray2)',
+          padding: '10px 12px 10px 16px', borderBottom: '1px solid var(--gray3)',
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6,
         }}>
-          WhatsApp
+          <span style={{
+            fontSize: 11, fontWeight: 800, textTransform: 'uppercase',
+            letterSpacing: '0.08em', color: 'var(--gray2)',
+          }}>WhatsApp</span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            {syncFeedback && (
+              <span style={{
+                fontSize: 10, fontWeight: 700,
+                color: syncFeedback === 'success' ? '#166534' : '#9a2008',
+              }}>
+                {syncFeedback === 'success' ? 'Sincronizado' : 'Falha ao sincronizar'}
+              </span>
+            )}
+            <button
+              onClick={() => { void syncNow() }}
+              disabled={syncing}
+              title="Sincronizar conversas agora"
+              style={{
+                fontSize: 10, fontWeight: 700, padding: '3px 9px', borderRadius: 99,
+                border: '1px solid var(--gray3)', background: 'transparent',
+                fontFamily: 'inherit', cursor: syncing ? 'not-allowed' : 'pointer',
+                color: syncing ? 'var(--gray3)' : 'var(--gray2)',
+              }}
+            >
+              {syncing ? '⟳' : '↺'} Sincronizar
+            </button>
+          </div>
         </div>
 
         <div style={{ padding: '8px 10px', borderBottom: '1px solid var(--gray3)' }}>

--- a/app/api/sdr/sync/route.ts
+++ b/app/api/sdr/sync/route.ts
@@ -1,0 +1,68 @@
+// POST /api/sdr/sync
+//
+// On-demand sync for the authenticated tenant: runs runSync() on every connected
+// data_source belonging to the tenant, skipping sources whose module is disabled.
+// Mirrors the logic of /api/cron/sync but scoped to the session tenant.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { dataSources, tenantModules } from '@/lib/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { assertEntitlement } from '@/lib/entitlements'
+import { runSync } from '@/lib/sync/runner'
+import { getModuleKeyForProvider } from '@/lib/modules'
+
+const MODULE_KEY = 'integration.ycloud-whatsapp'
+
+export async function POST() {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { tenantId } = session.user
+  const denied = await assertEntitlement(tenantId, MODULE_KEY)
+  if (denied) return denied
+
+  const enabledRows = await db
+    .select({ k: tenantModules.moduleKey })
+    .from(tenantModules)
+    .where(and(eq(tenantModules.tenantId, tenantId), eq(tenantModules.enabled, true)))
+  const enabledKeys = new Set(enabledRows.map(r => r.k))
+
+  const sources = await db
+    .select()
+    .from(dataSources)
+    .where(and(eq(dataSources.tenantId, tenantId), eq(dataSources.status, 'connected')))
+
+  const syncedAt = new Date().toISOString()
+  const results: Array<{
+    providerKey: string
+    status: string
+    counts?: object
+    error?: string
+  }> = []
+
+  for (const ds of sources) {
+    const moduleKey = getModuleKeyForProvider(ds.providerKey)
+    if (!moduleKey || !enabledKeys.has(moduleKey)) {
+      results.push({ providerKey: ds.providerKey, status: 'module_disabled' })
+      continue
+    }
+
+    try {
+      const result = await runSync(ds)
+      results.push({
+        providerKey: ds.providerKey,
+        status:      result.status,
+        counts:      result.counts,
+        error:       result.error,
+      })
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.error(`[sdr/sync] dataSource=${ds.id} tenant=${tenantId}`, msg)
+      results.push({ providerKey: ds.providerKey, status: 'error', error: msg })
+    }
+  }
+
+  return NextResponse.json({ ok: true, syncedAt, results })
+}


### PR DESCRIPTION
As conversas (incl. disparos do blast) só apareciam após o cron diário (`/api/cron/all`, 3h UTC). Este PR adiciona sync sob demanda.

## Mudanças
- **`/api/sdr/sync`** (POST, novo): autenticado por sessão, escopado ao tenant — roda `runSync` nos data_sources conectados do tenant (espelha `/api/cron/sync`, mas tenant-scoped e sem CRON_SECRET).
- **Conversas**: botão **"Sincronizar agora"** que dispara o sync e recarrega a lista (via `syncEpoch` nas deps do fetch). Feedback de sucesso/erro.

App não escreve no Supabase — `runSync` só lê da fonte e grava nas tabelas canônicas do Turso. `npx tsc --noEmit` limpo.

> Complemento (PR à parte): cron `/api/cron/sync` mais frequente no `vercel.json` (requer Vercel Pro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)