### PR TITLE
feat: Conversas sincroniza ao abrir a tela

### DIFF
--- a/app/(app)/sdr-ia/conversas/page.tsx
+++ b/app/(app)/sdr-ia/conversas/page.tsx
@@ -311,6 +311,7 @@ export default function ConversasPage() {
   const prevMsgCountRef         = useRef(0)
   const scrollToBottomOnLoadRef = useRef(false)
   const lidasRef                = useRef<Record<string, number>>({})
+  const didMountSyncRef         = useRef(false)
 
   // ── Fetch session list ──────────────────────────────────────────────────────
   useEffect(() => {
@@ -382,6 +383,13 @@ export default function ConversasPage() {
     lidasRef.current = stored
     setLidas(stored)
   }, [])
+
+  // Auto-sync once on mount so conversations are fresh when the page opens
+  useEffect(() => {
+    if (didMountSyncRef.current) return
+    didMountSyncRef.current = true
+    void syncNow()
+  }, [])  // eslint-disable-line react-hooks/exhaustive-deps
 
   // Debounce search input — avoids filtering on every keystroke
   useEffect(() => {


### PR DESCRIPTION
No plano Hobby do Vercel não há cron sub-diário, então Conversas passa a **sincronizar sozinha ao abrir**.

- useEffect de mount (guarda por `useRef` contra o double-invoke do StrictMode) chama `syncNow()` uma vez ao abrir `/sdr-ia/conversas`.
- A lista recarrega via `syncEpoch` (já existente). Botão manual "Sincronizar agora" mantido.

`npx tsc --noEmit` limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)