### PR TITLE
feat: import sinaliza números suspeitos (sem o 9)

### DIFF
--- a/app/(app)/sdr-ia/leads/page.tsx
+++ b/app/(app)/sdr-ia/leads/page.tsx
@@ -27,6 +27,7 @@ interface ImportResult {
   importados?:  number
   ignorados?:   { total: number; amostra: Array<{ linha: number; motivo: string }> }
   duplicados?:  { total: number; amostra: Array<{ linha: number; telefone: string }> }
+  suspeitos?:   { total: number; amostra: Array<{ linha: number; telefone: string }> }
   n8nStatus?:   number
   leadIds?:        string[]
   existingLeadIds?: string[]
@@ -536,6 +537,37 @@ export default function LeadsPage() {
                     )}
                   </div>
                 </details>
+              )}
+
+              {(importResult.suspeitos?.total ?? 0) > 0 && (
+                <div style={{
+                  marginTop: 10, padding: '10px 14px', borderRadius: 10,
+                  background: 'rgba(245,158,11,0.07)', border: '1px solid rgba(245,158,11,0.35)',
+                }}>
+                  <div style={{ fontSize: 12, fontWeight: 700, color: '#92400e', marginBottom: 4 }}>
+                    ⚠ {importResult.suspeitos!.total} número{importResult.suspeitos!.total !== 1 ? 's' : ''} podem estar sem o 9 (possível celular incompleto) — confira na planilha. O WhatsApp pode recusar (erro de não-entrega).
+                  </div>
+                  <details>
+                    <summary style={{
+                      fontSize: 12, color: '#92400e', cursor: 'pointer',
+                      fontWeight: 600, userSelect: 'none' as const,
+                    }}>
+                      Suspeitos ({importResult.suspeitos!.total})
+                    </summary>
+                    <div style={{ marginTop: 6, display: 'flex', flexDirection: 'column', gap: 3 }}>
+                      {importResult.suspeitos!.amostra.map((it, i) => (
+                        <div key={i} style={{ fontSize: 11, color: '#78350f', fontFamily: 'monospace' }}>
+                          Linha {it.linha}: {it.telefone}
+                        </div>
+                      ))}
+                      {importResult.suspeitos!.total > importResult.suspeitos!.amostra.length && (
+                        <div style={{ fontSize: 11, color: '#92400e', fontStyle: 'italic' }}>
+                          … e mais {importResult.suspeitos!.total - importResult.suspeitos!.amostra.length}
+                        </div>
+                      )}
+                    </div>
+                  </details>
+                </div>
               )}
 
               <div style={{ fontSize: 11, color: 'var(--gray2)', marginTop: 10, lineHeight: 1.5 }}>

--- a/app/api/sdr/leads/import/route.ts
+++ b/app/api/sdr/leads/import/route.ts
@@ -166,12 +166,14 @@ export async function POST(request: Request) {
   }
 
   // ── ETL: normalize + classify + dedup within file ────────────────────────────
-  type IgnoredEntry = { linha: number; motivo: string }
-  type DupEntry     = { linha: number; telefone: string }
-  type LeadEntry    = { name: string; phone: string; company: string; source: string; status: string }
+  type IgnoredEntry  = { linha: number; motivo: string }
+  type DupEntry      = { linha: number; telefone: string }
+  type SuspeitoEntry = { linha: number; telefone: string }
+  type LeadEntry     = { name: string; phone: string; company: string; source: string; status: string }
 
   const ignorados:  IgnoredEntry[]                               = []
   const duplicados: DupEntry[]                                   = []
+  const suspeitos:  SuspeitoEntry[]                             = []
   const candidatos: Array<LeadEntry & { linha: number; key: string }> = []
   const seenKeys   = new Set<string>()
 
@@ -212,6 +214,16 @@ export async function POST(request: Request) {
     seenKeys.add(key)
 
     candidatos.push({ linha, name, phone: normalized, company, source, status, key })
+  }
+
+  // ── Detect suspicious BR numbers (10-digit national, digit after DDD is 2-5) ──
+  // ensureBr9 will NOT fix these — they're ambiguous (landline or mobile without 9th digit).
+  for (const c of candidatos) {
+    if (!c.phone.startsWith('+55')) continue
+    const national = c.phone.slice(3)
+    if (national.length === 10 && national[2] >= '2' && national[2] <= '5') {
+      suspeitos.push({ linha: c.linha, telefone: c.phone })
+    }
   }
 
   // ── Dedup against Supabase (SOMENTE SELECT — nunca escreve) ──────────────────
@@ -334,6 +346,10 @@ export async function POST(request: Request) {
     duplicados: {
       total:   duplicados.length,
       amostra: duplicados.slice(0, AMOSTRA_MAX),
+    },
+    suspeitos: {
+      total:   suspeitos.length,
+      amostra: suspeitos.slice(0, AMOSTRA_MAX),
     },
     n8nStatus,
     leadIds,


### PR DESCRIPTION
Disparos para números incompletos (BR sem o 9) falham no WhatsApp com erro **131026** (não-entregável). O `ensureBr9` corrige só os casos claros (dígito após DDD 6-9); os ambíguos (2-5) ele deixa quieto para não corromper fixos. Este PR avisa o usuário sobre esses ambíguos.

## Mudanças
- **import**: detecta números `+55` com nacional de 10 dígitos e dígito após DDD entre 2-5; devolve `suspeitos: { total, amostra }`.
- **leads (relatório)**: aviso âmbar + `<details>` com a amostra quando há suspeitos. Informativo, não bloqueia.

`npx tsc --noEmit` limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)