### PR TITLE
feat: skeletons/shimmer nas telas principais

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -12,6 +12,7 @@ import type { DataTableColumn } from '@/components/widgets/DataTable'
 import { BarChart } from '@/components/widgets/BarChart'
 import type { BarChartItem } from '@/components/widgets/BarChart'
 import { useModules } from '@/components/ModulesProvider'
+import { SkeletonKpiCards, SkeletonBlock } from '@/components/Skeleton'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -325,9 +326,14 @@ export default function DashboardPage() {
       </div>
 
       {loading && (
-        <div style={{ padding: '48px 0', textAlign: 'center', fontSize: 13, color: 'var(--gray2)' }}>
-          Carregando...
-        </div>
+        <>
+          <SkeletonKpiCards count={4} />
+          <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 3fr) minmax(0, 2fr)', gap: 16, marginBottom: 16 }}>
+            <SkeletonBlock height={200} />
+            <SkeletonBlock height={200} />
+          </div>
+          <SkeletonBlock height={180} />
+        </>
       )}
 
       {!loading && !hasData && <EmptyState />}

--- a/app/(app)/sdr-ia/contatos/page.tsx
+++ b/app/(app)/sdr-ia/contatos/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { Search } from 'lucide-react'
 import { DataTable } from '@/components/widgets/DataTable'
 import type { DataTableColumn } from '@/components/widgets/DataTable'
+import { SkeletonTable } from '@/components/Skeleton'
 import { timeAgo } from '@/lib/format'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -188,9 +189,7 @@ export default function ContatosPage() {
 
       {/* ── Loading ────────────────────────────────────────────────── */}
       {loading && (
-        <div style={{ padding: '48px 0', textAlign: 'center', fontSize: 13, color: 'var(--gray2)' }}>
-          Carregando...
-        </div>
+        <SkeletonTable rows={8} colWidths={['28%', '18%', '18%', '18%', '12%']} />
       )}
 
       {/* ── Error ──────────────────────────────────────────────────── */}

--- a/app/(app)/sdr-ia/conversas/page.tsx
+++ b/app/(app)/sdr-ia/conversas/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react'
 import type { CSSProperties } from 'react'
 import { timeAgo } from '@/lib/format'
+import { Skeleton, SkeletonSessionList } from '@/components/Skeleton'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -625,11 +626,7 @@ export default function ConversasPage() {
         </div>
 
         <div style={{ flex: 1, overflowY: 'auto' }}>
-          {sessLoading && (
-            <p style={{ padding: '20px 16px', fontSize: 12, color: 'var(--gray2)', margin: 0 }}>
-              Carregando...
-            </p>
-          )}
+          {sessLoading && <SkeletonSessionList items={7} />}
           {sessError && (
             <p style={{ padding: '20px 16px', fontSize: 12, color: '#c0392b', margin: 0 }}>
               Falha ao carregar conversas
@@ -746,7 +743,13 @@ export default function ConversasPage() {
             display: 'flex', alignItems: 'center', gap: 12, flexShrink: 0, minHeight: 56,
           }}>
             {threadLoading ? (
-              <span style={{ fontSize: 13, color: 'var(--gray2)' }}>Carregando...</span>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1 }}>
+                <Skeleton circle width={34} height={34} />
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 7, flex: 1 }}>
+                  <Skeleton width="40%" height={13} />
+                  <Skeleton width="25%" height={10} />
+                </div>
+              </div>
             ) : thread ? (
               <>
                 <div style={{

--- a/app/(app)/sdr-ia/leads/page.tsx
+++ b/app/(app)/sdr-ia/leads/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Search } from 'lucide-react'
+import { SkeletonTable } from '@/components/Skeleton'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -643,9 +644,7 @@ export default function LeadsPage() {
 
       {/* ── Loading ────────────────────────────────────────────────── */}
       {loading && (
-        <div style={{ padding: '48px 0', textAlign: 'center', fontSize: 13, color: 'var(--gray2)' }}>
-          Carregando...
-        </div>
+        <SkeletonTable rows={8} colWidths={['28%', '18%', '18%', '14%', '10%']} />
       )}
 
       {/* ── Error ──────────────────────────────────────────────────── */}

--- a/app/(app)/sdr-ia/parametros/page.tsx
+++ b/app/(app)/sdr-ia/parametros/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { AlertTriangle, ChevronDown, ExternalLink, Eye, EyeOff } from 'lucide-react'
+import { SkeletonForm, SkeletonBlock } from '@/components/Skeleton'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -359,7 +360,12 @@ export default function ParametrosPage() {
   }
 
   if (loading) {
-    return <div style={{ padding: '48px 0', textAlign: 'center', fontSize: 13, color: 'var(--gray2)' }}>Carregando...</div>
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <SkeletonBlock height={56} style={{ borderRadius: 12 }} />
+        <SkeletonForm rows={5} />
+      </div>
+    )
   }
 
   const hasTemplates = settings.templates.length > 0

--- a/components/Skeleton.tsx
+++ b/components/Skeleton.tsx
@@ -1,0 +1,142 @@
+import type { CSSProperties } from 'react'
+
+interface SkeletonProps {
+  width?:   number | string
+  height?:  number | string
+  radius?:  number | string
+  circle?:  boolean
+  style?:   CSSProperties
+}
+
+export function Skeleton({ width = '100%', height = 14, radius = 6, circle, style }: SkeletonProps) {
+  return (
+    <div
+      className="shimmer-bar"
+      style={{
+        width,
+        height,
+        borderRadius: circle ? '50%' : radius,
+        background: 'var(--gray3)',
+        flexShrink: 0,
+        ...style,
+      }}
+    />
+  )
+}
+
+// N stacked text-line bars
+export function SkeletonText({ lines = 2, gap = 8 }: { lines?: number; gap?: number }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap }}>
+      {Array.from({ length: lines }, (_, i) => (
+        <Skeleton key={i} width={i === lines - 1 && lines > 1 ? '65%' : '100%'} height={13} />
+      ))}
+    </div>
+  )
+}
+
+// Table skeleton: white card with N rows × cols widths
+interface SkeletonTableProps {
+  rows?:     number
+  colWidths?: (number | string)[]
+}
+export function SkeletonTable({ rows = 7, colWidths = ['30%', '20%', '20%', '15%', '10%'] }: SkeletonTableProps) {
+  return (
+    <div style={{
+      background: 'var(--white)', borderRadius: 16,
+      border: '1px solid var(--gray3)', overflow: 'hidden',
+    }}>
+      {/* header ghost */}
+      <div style={{
+        background: 'var(--bg)', padding: '10px 16px',
+        borderBottom: '1px solid var(--gray3)',
+        display: 'flex', gap: 16, alignItems: 'center',
+      }}>
+        <Skeleton width={14} height={14} radius={3} />
+        {colWidths.map((w, i) => <Skeleton key={i} width={w} height={10} />)}
+      </div>
+      {/* rows */}
+      {Array.from({ length: rows }, (_, r) => (
+        <div
+          key={r}
+          style={{
+            padding: '13px 16px',
+            borderBottom: r < rows - 1 ? '1px solid var(--gray3)' : 'none',
+            display: 'flex', gap: 16, alignItems: 'center',
+          }}
+        >
+          <Skeleton width={14} height={14} radius={3} />
+          {colWidths.map((w, i) => <Skeleton key={i} width={w} height={13} />)}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// Session list skeleton for conversas sidebar
+export function SkeletonSessionList({ items = 6 }: { items?: number }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      {Array.from({ length: items }, (_, i) => (
+        <div
+          key={i}
+          style={{
+            display: 'flex', alignItems: 'flex-start', gap: 9,
+            padding: '10px 12px', borderBottom: '1px solid var(--gray3)',
+          }}
+        >
+          <Skeleton circle width={30} height={30} style={{ marginTop: 1 }} />
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <Skeleton width="60%" height={12} />
+            <Skeleton width="85%" height={10} />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// KPI card skeletons for dashboard
+export function SkeletonKpiCards({ count = 4 }: { count?: number }) {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: `repeat(${count}, minmax(0, 1fr))`, gap: 14, marginBottom: 24 }}>
+      {Array.from({ length: count }, (_, i) => (
+        <div key={i} style={{
+          background: 'var(--white)', borderRadius: 16,
+          border: '1px solid var(--gray3)', padding: '20px 22px',
+          display: 'flex', flexDirection: 'column', gap: 12,
+        }}>
+          <Skeleton width="55%" height={11} />
+          <Skeleton width="45%" height={28} radius={6} />
+          <Skeleton width="70%" height={10} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// Generic block placeholder (for charts / wide cards)
+export function SkeletonBlock({ height = 180, style }: { height?: number; style?: CSSProperties }) {
+  return (
+    <Skeleton
+      width="100%"
+      height={height}
+      radius={16}
+      style={{ background: 'var(--gray3)', ...style }}
+    />
+  )
+}
+
+// Form skeleton: label + input rows
+export function SkeletonForm({ rows = 5 }: { rows?: number }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+      {Array.from({ length: rows }, (_, i) => (
+        <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+          <Skeleton width="30%" height={11} />
+          <Skeleton width="100%" height={38} radius={10} />
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
Substitui o "Carregando..." genérico por skeletons/shimmer nas telas principais.

- Novo `components/Skeleton.tsx` reutilizável: `Skeleton`, `SkeletonText`, `SkeletonTable`, `SkeletonSessionList`, `SkeletonKpiCards`, `SkeletonBlock`, `SkeletonForm` (usando o `.shimmer-bar` já existente em globals.css).
- Aplicado em **dashboard, leads, contatos, conversas (lista + thread) e parâmetros**, com formas que imitam o conteúdo.

`npx tsc --noEmit` limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)