### PR TITLE
feat: dashboard com nome e clique para abrir a conversa

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Settings } from 'lucide-react'
 import { KpiCard } from '@/components/widgets/KpiCard'
@@ -35,7 +36,7 @@ interface SdrBiData {
   kpis: { contatos: number; taxaResposta: number; reunioes: number; conversao: number }
   funnel: { stageKey: string; stageName: string; count: number; order: number }[]
   sentiment: { id: string; label: string; color: string; count: number }[]
-  recent: { sessionId: string; source: string; lastContact: number | null; msgs: number }[]
+  recent: { sessionId: string; source: string; lastContact: number | null; msgs: number; name: string | null }[]
   whatsapp?: WaBlock
   lastSyncAt: number | null
 }
@@ -155,6 +156,16 @@ function SourceBadge({ source }: { source: string }) {
 
 const TABLE_COLS: DataTableColumn[] = [
   {
+    key: 'name',
+    label: 'Nome',
+    sortable: true,
+    format: (v) => (
+      <span style={{ fontWeight: 700, color: v ? 'var(--black)' : 'var(--gray2)' }}>
+        {(v as string | null) ?? '—'}
+      </span>
+    ),
+  },
+  {
     key: 'source',
     label: 'Origem',
     sortable: false,
@@ -162,7 +173,7 @@ const TABLE_COLS: DataTableColumn[] = [
   },
   {
     key: 'sessionLabel',
-    label: 'Sessão',
+    label: 'Telefone',
     sortable: false,
     format: (v) => (
       <span title={v as string} style={{ fontFamily: 'monospace', fontSize: 11, color: 'var(--gray2)' }}>
@@ -226,6 +237,7 @@ export default function DashboardPage() {
   const [loading, setLoading] = useState(true)
   const [ready, setReady]     = useState(false)
 
+  const router    = useRouter()
   const modules   = useModules()
   const hasYCloud = modules.includes('integration.ycloud-whatsapp')
 
@@ -279,8 +291,10 @@ export default function DashboardPage() {
 
   // Derived table rows
   const tableRows = (data?.recent ?? []).map(r => ({
+    name:         r.name,
     source:       r.source,
     sessionLabel: r.sessionId,
+    sessionId:    r.sessionId,
     msgs:         r.msgs,
     lastContact:  r.lastContact ?? 0,
   }))
@@ -500,6 +514,7 @@ export default function DashboardPage() {
                 defaultSortKey="lastContact"
                 defaultSortDir="desc"
                 emptyMessage="Nenhuma sessão encontrada no período"
+                onRowClick={row => router.push(`/sdr-ia/conversas?session=${encodeURIComponent(String(row.sessionId ?? ''))}`)}
               />
             </div>
           )}

--- a/app/(app)/sdr-ia/conversas/page.tsx
+++ b/app/(app)/sdr-ia/conversas/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { useSearchParams } from 'next/navigation'
 import type { CSSProperties } from 'react'
 import { timeAgo } from '@/lib/format'
 import { Skeleton, SkeletonSessionList } from '@/components/Skeleton'
@@ -313,6 +314,9 @@ export default function ConversasPage() {
   const scrollToBottomOnLoadRef = useRef(false)
   const lidasRef                = useRef<Record<string, number>>({})
   const didMountSyncRef         = useRef(false)
+  const didDeepLinkRef          = useRef(false)
+
+  const searchParams = useSearchParams()
 
   // ── Fetch session list ──────────────────────────────────────────────────────
   useEffect(() => {
@@ -384,6 +388,17 @@ export default function ConversasPage() {
     lidasRef.current = stored
     setLidas(stored)
   }, [])
+
+  // Deep-link: open ?session=<id> on mount (once, StrictMode-safe via ref guard)
+  // supabase-n8n sessionIds arrive as plain digits (no '+') — normalize to E.164.
+  useEffect(() => {
+    if (didDeepLinkRef.current) return
+    const raw = searchParams.get('session')
+    if (!raw) return
+    didDeepLinkRef.current = true
+    const sessionId = raw.startsWith('+') ? raw : '+' + raw
+    loadThread(sessionId)
+  }, [])  // eslint-disable-line react-hooks/exhaustive-deps
 
   // Auto-sync once on mount so conversations are fresh when the page opens
   useEffect(() => {

--- a/app/api/bi/sdr/route.ts
+++ b/app/api/bi/sdr/route.ts
@@ -18,8 +18,8 @@
 import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
 import { db } from '@/lib/db'
-import { events, conversations, funnelSnapshots, dataSources } from '@/lib/db/schema'
-import { and, desc, eq, gte, lte, sql } from 'drizzle-orm'
+import { events, conversations, contacts, funnelSnapshots, dataSources } from '@/lib/db/schema'
+import { and, desc, eq, gte, inArray, lte, sql } from 'drizzle-orm'
 import { assertEntitlement } from '@/lib/entitlements'
 
 const DAY = 86_400_000
@@ -222,6 +222,34 @@ export async function GET(request: Request) {
     .slice(0, 50)
     .map(({ source, sessionId, lastContact, msgs }) => ({ sessionId, source, lastContact, msgs }))
 
+  // ── Name lookup: match recent sessionIds against contacts ─────────────────
+  // supabase-n8n sessionIds are plain digits (no '+'); YCloud contacts store
+  // externalId as E.164 (with '+'). Query both forms and resolve via fallback.
+  const recentIds = recent.map(r => r.sessionId)
+  const allContactIds = Array.from(new Set([
+    ...recentIds,
+    ...recentIds.map(id => id.startsWith('+') ? id : '+' + id),
+  ]))
+
+  const contactRows = allContactIds.length > 0
+    ? await db
+        .select({ externalId: contacts.externalId, name: contacts.name })
+        .from(contacts)
+        .where(and(
+          eq(contacts.tenantId, tenantId),
+          inArray(contacts.externalId, allContactIds),
+        ))
+    : []
+
+  const contactNameMap = new Map(contactRows.map(c => [c.externalId, c.name]))
+
+  const recentWithName = recent.map(r => ({
+    ...r,
+    name: contactNameMap.get(r.sessionId)
+      ?? contactNameMap.get('+' + r.sessionId)
+      ?? null,
+  }))
+
   // ── WhatsApp metrics ──────────────────────────────────────────────────────
   //
   //  Totals: exact SQL aggregates (no row limit — always correct).
@@ -284,7 +312,7 @@ export async function GET(request: Request) {
       order:     Number(r.order),
     })),
     sentiment,
-    recent,
+    recent: recentWithName,
     whatsapp: {
       totals: waTotals,
       rates:  waRates,


### PR DESCRIPTION
A tabela de sessões recentes do Dashboard passa a mostrar o **nome** e, ao clicar, abre a conversa nas Conversas (em tempo real, pronta para responder).

## Mudanças
- **`/api/bi/sdr`**: cada sessão recente ganha `name` (lookup em `contacts`, tolerante a sessionId com/sem `+` — supabase-n8n digits → contacts E.164).
- **Dashboard**: coluna **Nome** + linha clicável → `/sdr-ia/conversas?session=<sessionId>`.
- **Conversas**: lê `?session=` no mount (normaliza para E.164) e abre a thread direto (`loadThread`), independente de estar na 1ª página. Composer/janela-24h já existentes cobrem o "interagir".

`npx tsc --noEmit` limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)