### PR TITLE
style: sistema de elevação (sombras) — fundação visual 1/4

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -19,7 +19,10 @@
   --radius-md: 12px;
   --radius-lg: 16px;
   --radius-pill: 100px;
-  --shadow: 0 1px 3px rgba(0,0,0,0.06);
+  --shadow: 0 1px 2px rgba(17,24,39,.05), 0 4px 12px rgba(17,24,39,.05);
+  --shadow-sm: 0 1px 2px rgba(17,24,39,.05);
+  --shadow-md: 0 1px 2px rgba(17,24,39,.05), 0 8px 20px rgba(17,24,39,.07);
+  --shadow-lg: 0 4px 12px rgba(17,24,39,.06), 0 16px 40px rgba(17,24,39,.10);
   --transition: .2s ease;
 }
 

--- a/components/widgets/DataTable.tsx
+++ b/components/widgets/DataTable.tsx
@@ -178,8 +178,9 @@ export function DataTable({
               key={i}
               onClick={onRowClick ? () => onRowClick(row) : undefined}
               style={{
-                background: 'var(--white)', border: '1px solid var(--gray3)',
+                background: 'var(--white)', border: '1px solid #ECECE9',
                 borderRadius: 12, padding: 14, marginBottom: 10,
+                boxShadow: 'var(--shadow-md)',
                 cursor: onRowClick ? 'pointer' : 'default',
               }}
             >

--- a/components/widgets/KpiCard.tsx
+++ b/components/widgets/KpiCard.tsx
@@ -78,7 +78,7 @@ export function KpiCard({
       onMouseLeave={() => setHov(false)}
       style={{
         background: 'var(--white)',
-        border: '1px solid var(--gray3)',
+        border: '1px solid #ECECE9',
         borderLeft: `4px solid ${accent}`,
         borderRadius: 12,
         padding: '18px 20px',
@@ -87,7 +87,7 @@ export function KpiCard({
         transform: hov ? 'translateY(-4px) scale(1.01)' : 'translateY(0) scale(1)',
         boxShadow: hov
           ? `0 10px 28px rgba(0,0,0,0.10), inset 0 0 0 1px ${accent}30`
-          : 'var(--shadow)',
+          : 'var(--shadow-md)',
         display: 'flex', flexDirection: 'column',
       }}
     >


### PR DESCRIPTION
Primeiro item da fundação visual: troca o visual flat (borda fina) por elevação suave.

- globals.css: `--shadow-sm/md/lg` + `--shadow` melhorado (propaga p/ as ~10 telas que já usam o token).
- KpiCard / DataTable: borda leve + `var(--shadow-md)` (lift no hover do KPI).

tsc limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)