### PR TITLE
style: neutros + vermelho de destaque — fundação visual 2/4

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,6 +24,10 @@
   --shadow-md: 0 1px 2px rgba(17,24,39,.05), 0 8px 20px rgba(17,24,39,.07);
   --shadow-lg: 0 4px 12px rgba(17,24,39,.06), 0 16px 40px rgba(17,24,39,.10);
   --transition: .2s ease;
+  --ink:   #16181D;
+  --ink-2: #3A3D44;
+  --muted: #8A8A92;
+  --line:  #ECECE9;
 }
 
 @theme {

--- a/components/widgets/KpiCard.tsx
+++ b/components/widgets/KpiCard.tsx
@@ -91,17 +91,17 @@ export function KpiCard({
         display: 'flex', flexDirection: 'column',
       }}
     >
-      <div style={{ fontSize: 10, fontWeight: 800, color: 'var(--gray2)', letterSpacing: '0.08em', textTransform: 'uppercase', marginBottom: 10 }}>
+      <div style={{ fontSize: 10, fontWeight: 800, color: 'var(--muted)', letterSpacing: '0.08em', textTransform: 'uppercase', marginBottom: 10 }}>
         {label}
       </div>
       <div style={{
         fontSize: display.length > 14 ? 20 : display.length > 10 ? 23 : 26,
-        fontWeight: 800, color: accent, lineHeight: 1,
+        fontWeight: 800, color: 'var(--ink)', lineHeight: 1,
         transition: 'font-size 0.2s ease',
         letterSpacing: '-0.02em',
         wordBreak: 'break-all',
       }}>{display}</div>
-      {sub && <div style={{ fontSize: 11, color: 'var(--gray2)', marginTop: 5, fontWeight: 500 }}>{sub}</div>}
+      {sub && <div style={{ fontSize: 11, color: 'var(--muted)', marginTop: 5, fontWeight: 500 }}>{sub}</div>}
       <ChangeBadge value={change ?? null} />
     </div>
   )


### PR DESCRIPTION
Segundo item: hierarquia de neutros e vermelho reservado para ação/destaque.

- globals.css: `--ink` / `--ink-2` / `--muted` / `--line` (tokens antigos mantidos).
- KpiCard: número neutro (`--ink`), label/sub `--muted`; `accent` fica só na faixa lateral, não no número.

tsc limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)