### PR TITLE
fix: botões com CSS real (primário sólido + secundário com borda)

### DIFF
--- a/app/(app)/sdr-ia/leads/page.tsx
+++ b/app/(app)/sdr-ia/leads/page.tsx
@@ -398,14 +398,7 @@ export default function LeadsPage() {
           <a
             href="/api/sdr/leads/template"
             download="modelo-leads.xlsx"
-            style={{
-              display: 'inline-flex', alignItems: 'center',
-              padding: '8px 16px', borderRadius: 99,
-              fontSize: 12, fontWeight: 700, textDecoration: 'none',
-              border: '1px solid var(--gray3)',
-              background: 'transparent', color: 'var(--gray)',
-              cursor: 'pointer', transition: 'all .15s', whiteSpace: 'nowrap' as const,
-            }}
+            className="btn btn-secondary btn-sm"
           >
             Baixar modelo
           </a>

--- a/app/globals.css
+++ b/app/globals.css
@@ -197,3 +197,34 @@ body {
 
 .focus\:border-primary:focus { border-color: var(--primary) !important; }
 .focus\:ring-primary:focus { box-shadow: 0 0 0 3px var(--primary-dim) !important; }
+
+/* ── Button system ── */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  font-weight: 600; font-family: inherit; white-space: nowrap; cursor: pointer;
+  border: 1px solid transparent; border-radius: var(--radius-md);
+  transition: filter .15s ease, background .15s ease, border-color .15s ease;
+  text-decoration: none;
+}
+.btn:disabled, .btn[disabled]           { opacity: .4; cursor: not-allowed; }
+.btn:focus-visible                      { outline: none; box-shadow: 0 0 0 3px var(--primary-dim); }
+
+.btn-primary                            { background: var(--primary); color: #fff; border-color: var(--primary); box-shadow: var(--shadow-sm); }
+.btn-primary:hover:not(:disabled)       { filter: brightness(.92); }
+.btn-primary:active:not(:disabled)      { filter: brightness(.85); }
+
+.btn-secondary                          { background: var(--white); color: var(--ink-2); border-color: var(--gray3); }
+.btn-secondary:hover:not(:disabled)     { background: var(--bg); }
+
+.btn-ghost                              { background: transparent; color: var(--ink-2); border-color: transparent; }
+.btn-ghost:hover:not(:disabled)         { background: var(--primary-dim); }
+
+.btn-success                            { background: var(--green); color: #fff; border-color: var(--green); }
+.btn-success:hover:not(:disabled)       { filter: brightness(.92); }
+
+.btn-danger                             { background: transparent; color: var(--red); border-color: rgba(217,48,37,.25); }
+.btn-danger:hover:not(:disabled)        { background: rgba(217,48,37,.06); }
+
+.btn-sm { padding: 6px 12px;  font-size: 12px; }
+.btn-md { padding: 9px 16px;  font-size: 13px; }
+.btn-lg { padding: 11px 22px; font-size: 14px; }

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -9,38 +9,11 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   size?: Size
 }
 
-const base = [
-  'inline-flex items-center justify-center gap-2 font-semibold whitespace-nowrap',
-  'rounded-[var(--radius-md)] border cursor-pointer transition-all duration-200',
-  'disabled:opacity-40 disabled:cursor-not-allowed',
-  'focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_var(--primary-dim)]',
-].join(' ')
-
-const variants: Record<Variant, string> = {
-  primary:
-    'bg-[var(--primary)] text-white border-[var(--primary)] shadow-[var(--shadow-sm)] hover:brightness-90 active:brightness-75',
-  secondary:
-    'bg-[var(--white)] text-[var(--ink-2)] border-[var(--line)] hover:bg-[var(--bg)]',
-  ghost:
-    'bg-transparent text-[var(--ink-2)] border-transparent hover:bg-[var(--primary-dim)]',
-  success:
-    'bg-[var(--green)] text-white border-[var(--green)] hover:brightness-90',
-  danger:
-    'bg-transparent text-[var(--red)] border-[rgba(217,48,37,0.25)] hover:bg-[rgba(217,48,37,0.06)]',
-}
-
-const sizes: Record<Size, string> = {
-  sm: 'px-3 py-1.5 text-xs',
-  md: 'px-4 py-2.5 text-[13px]',
-  lg: 'px-6 py-3 text-sm',
-}
-
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ variant = 'secondary', size = 'md', className, children, ...props }, ref) => (
     <button
       ref={ref}
-      style={{ fontFamily: 'inherit' }}
-      className={cn(base, variants[variant], sizes[size], className)}
+      className={cn('btn', `btn-${variant}`, `btn-${size}`, className)}
       {...props}
     >
       {children}


### PR DESCRIPTION
Corrige o render dos botões: as classes arbitrárias do Tailwind (`bg-[var(--primary)]`) não eram aplicadas — primário saía rosa, secundário/ghost sem borda.

- globals.css: sistema `.btn` com CSS real (var(--...)). Primário vermelho sólido + branco; secundário branco com borda `var(--gray3)` visível; ghost discreto; foco visível.
- Button.tsx: só aplica as classes (sem Tailwind arbitrário).
- "Baixar modelo" alinhado ao secundário (igual ao "Importar Excel").

tsc limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)