### PR TITLE
feat: feedback animado no disparo (starter pack B)

### DIFF
--- a/app/(app)/sdr-ia/leads/page.tsx
+++ b/app/(app)/sdr-ia/leads/page.tsx
@@ -82,6 +82,29 @@ function StatusBadge({ value }: { value: string | null }) {
   )
 }
 
+function ProportionBar({ started, total, skipped }: { started: number; total: number; skipped: number }) {
+  const [pct, setPct] = useState(0)
+  useEffect(() => {
+    const target = total > 0 ? Math.min(100, Math.round((started / total) * 100)) : 0
+    const raf = requestAnimationFrame(() => setPct(target))
+    return () => cancelAnimationFrame(raf)
+  }, [started, total])
+  return (
+    <div>
+      <div style={{ height: 6, borderRadius: 3, background: 'var(--primary-dim)', overflow: 'hidden', marginBottom: 6 }}>
+        <div style={{
+          height: '100%', borderRadius: 3, background: 'var(--primary)',
+          width: `${pct}%`, transition: 'width .5s ease-out',
+        }} />
+      </div>
+      <div style={{ fontSize: 11, color: 'var(--gray)', fontWeight: 500 }}>
+        {started} enviado{started !== 1 ? 's' : ''}
+        {skipped > 0 && <> · {skipped} ignorado{skipped !== 1 ? 's' : ''} (telefone inválido)</>}
+      </div>
+    </div>
+  )
+}
+
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function LeadsPage() {
@@ -1044,22 +1067,35 @@ export default function LeadsPage() {
                 )}
 
                 {blasting && (
-                  <div style={{ fontSize: 13, color: 'var(--gray2)', marginBottom: 18 }}>Disparando...</div>
+                  <div style={{ fontSize: 13, color: 'var(--gray2)', marginBottom: 18, display: 'flex', alignItems: 'center', gap: 4 }}>
+                    Disparando
+                    <span aria-hidden="true" style={{ display: 'inline-flex', gap: 3, marginLeft: 2 }}>
+                      <span className="blast-dot" />
+                      <span className="blast-dot" style={{ animationDelay: '.2s' }} />
+                      <span className="blast-dot" style={{ animationDelay: '.4s' }} />
+                    </span>
+                  </div>
                 )}
                 {blastResult && (
                   <div style={{
-                    marginBottom: 18, padding: '10px 14px', borderRadius: 10, fontSize: 13, fontWeight: 600,
+                    marginBottom: 18, padding: '10px 14px', borderRadius: 10,
                     background: blastResult.ok ? 'rgba(34,197,94,0.08)' : 'rgba(239,68,68,0.08)',
                     border: `1px solid ${blastResult.ok ? 'rgba(34,197,94,0.25)' : 'rgba(239,68,68,0.25)'}`,
-                    color: blastResult.ok ? '#15803d' : 'var(--red)',
                   }}>
-                    {blastResult.ok
-                      ? `✓ Disparo iniciado para ${blastResult.started} contato${blastResult.started !== 1 ? 's' : ''}`
-                      : `Erro ao disparar: ${friendlyBlastError(blastResult.error ?? 'erro desconhecido')}`
-                    }
-                    {blastResult.ok && (blastResult.skipped ?? 0) > 0 && (
-                      <div style={{ fontSize: 11, color: '#b45309', marginTop: 6, fontWeight: 500 }}>
-                        {blastResult.skipped} ignorado(s) por telefone inválido.
+                    {blastResult.ok ? (
+                      <>
+                        <div style={{ fontSize: 13, fontWeight: 700, color: '#15803d', marginBottom: 10 }}>
+                          ✓ Disparo iniciado para {blastResult.started} contato{blastResult.started !== 1 ? 's' : ''}
+                        </div>
+                        <ProportionBar
+                          started={blastResult.started ?? 0}
+                          total={blastResult.totalSolicitado ?? blastResult.started ?? 0}
+                          skipped={blastResult.skipped ?? 0}
+                        />
+                      </>
+                    ) : (
+                      <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--red)' }}>
+                        {`Erro ao disparar: ${friendlyBlastError(blastResult.error ?? 'erro desconhecido')}`}
                       </div>
                     )}
                   </div>
@@ -1078,6 +1114,7 @@ export default function LeadsPage() {
                       </Button>
                       <Button
                         variant="primary"
+                        className={blasting ? 'btn-pulse' : undefined}
                         onClick={runBlast}
                         disabled={blasting}
                       >
@@ -1099,6 +1136,7 @@ export default function LeadsPage() {
                       {!blastResult && (
                         <Button
                           variant="primary"
+                          className={blasting ? 'btn-pulse' : undefined}
                           onClick={() => {
                             if ((importResult?.semNome ?? 0) > 0) { setBlastPendingConfirm(true) }
                             else { void runBlast() }

--- a/app/globals.css
+++ b/app/globals.css
@@ -179,10 +179,27 @@ body {
 .animate-count-pop { animation: count-pop .35s ease-out both; }
 .tabular-nums { font-variant-numeric: tabular-nums; }
 
+@keyframes buttonPulse {
+  0%   { box-shadow: 0 0 0 0   rgba(225, 5, 4, 0.35); }
+  70%  { box-shadow: 0 0 0 6px rgba(225, 5, 4, 0);    }
+  100% { box-shadow: 0 0 0 0   rgba(225, 5, 4, 0);    }
+}
+.btn-pulse { animation: buttonPulse 1.3s ease-in-out infinite; }
+
+.blast-dot {
+  display: inline-block;
+  width: 4px; height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+  animation: pulse-dot 1s ease-in-out infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .shimmer-bar::after { animation: none; }
   .animate-slide-up  { animation: none; opacity: 1; transform: none; }
   .animate-count-pop { animation: none; opacity: 1; transform: none; }
+  .btn-pulse         { animation: none; }
+  .blast-dot         { animation: none; opacity: 1; transform: none; }
 }
 
 /* ── Scrollbar ── */


### PR DESCRIPTION
Pacote B: feedback de 'mensagens sendo enviadas' — honesto (indicativo + proporção final, sem progresso ao vivo falso, já que o app só recebe `{started:N}`).

- `@keyframes buttonPulse` + `.btn-pulse` no botão enquanto disparando.
- "Disparando" + 3 dots escalonados (`.blast-dot`, reusa pulse-dot).
- `ProportionBar`: preenche started/totalSolicitado em .5s ease-out, mostra enviados/ignorados.
- prefers-reduced-motion desliga as novas animações.

tsc limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)