### PR TITLE
feat: cascatas de entrada (starter pack C)

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -403,14 +403,16 @@ export default function DashboardPage() {
       {!loading && hasData && (
         <>
           {/* ── KPI Cards (SDR) ────────────────────────────────────── */}
-          <div className="animate-slide-up delay-2" style={{ display: 'grid', gridTemplateColumns: 'repeat(4, minmax(0, 1fr))', gap: 14, marginBottom: 24 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, minmax(0, 1fr))', gap: 14, marginBottom: 24 }}>
             <KpiCard
+              className="animate-slide-up delay-2"
               label="Contatos realizados"
               value={data!.kpis.contatos}
               accent="var(--primary-text)"
               sub={`de ${(data?.funnel.find(f => f.stageKey === 'leads')?.count ?? 0).toLocaleString('pt-BR')} leads recebidos`}
             />
             <KpiCard
+              className="animate-slide-up delay-3"
               label="Taxa de resposta"
               value={data!.kpis.taxaResposta}
               format={v => `${v}%`}
@@ -418,12 +420,14 @@ export default function DashboardPage() {
               sub="leads que responderam"
             />
             <KpiCard
+              className="animate-slide-up delay-4"
               label="Reuniões agendadas"
               value={data!.kpis.reunioes}
               accent="var(--green)"
               sub="com closer neste período"
             />
             <KpiCard
+              className="animate-slide-up delay-5"
               label="Conversão lead→reunião"
               value={data!.kpis.conversao}
               format={v => `${v}%`}
@@ -562,6 +566,7 @@ export default function DashboardPage() {
                 defaultSortKey="lastContact"
                 defaultSortDir="desc"
                 emptyMessage="Nenhuma sessão encontrada no período"
+                rowKey="sessionId"
                 onRowClick={row => router.push(`/sdr-ia/conversas?session=${encodeURIComponent(String(row.sessionId ?? ''))}`)}
               />
             </div>

--- a/app/(app)/sdr-ia/leads/page.tsx
+++ b/app/(app)/sdr-ia/leads/page.tsx
@@ -736,13 +736,15 @@ export default function LeadsPage() {
                 return (
                   <tr
                     key={lead.id}
+                    className="row-cascade"
                     onClick={() => toggleOne(lead.id)}
                     style={{
+                      '--row-delay': `${Math.min(i, 9) * 40}ms`,
                       borderBottom: isLast ? 'none' : '1px solid var(--gray3)',
                       background: checked ? 'var(--primary-dim)' : 'transparent',
                       borderLeft: `3px solid ${checked ? 'var(--primary)' : 'transparent'}`,
                       cursor: 'pointer', transition: 'background .12s, border-color .12s',
-                    }}
+                    } as React.CSSProperties}
                   >
                     <td style={{ padding: '11px 16px' }} onClick={e => e.stopPropagation()}>
                       <input

--- a/app/globals.css
+++ b/app/globals.css
@@ -194,12 +194,18 @@ body {
   animation: pulse-dot 1s ease-in-out infinite;
 }
 
+.row-cascade {
+  animation: rowExpand 0.35s ease-out both;
+  animation-delay: var(--row-delay, 0ms);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .shimmer-bar::after { animation: none; }
   .animate-slide-up  { animation: none; opacity: 1; transform: none; }
   .animate-count-pop { animation: none; opacity: 1; transform: none; }
   .btn-pulse         { animation: none; }
   .blast-dot         { animation: none; opacity: 1; transform: none; }
+  .row-cascade       { animation: none; opacity: 1; transform: none; }
 }
 
 /* ── Scrollbar ── */

--- a/components/widgets/DataTable.tsx
+++ b/components/widgets/DataTable.tsx
@@ -23,6 +23,8 @@ export interface DataTableProps {
   maxHeight?: number
   /** Mobile rendering strategy. Defaults to 'cards'. Only affects < 768px. */
   mobileMode?: 'cards' | 'scroll'
+  /** Column key whose value uniquely identifies a row. Used to stabilise animation keys so re-sort doesn't re-trigger the cascade. */
+  rowKey?: string
 }
 
 // ─── DataTable ────────────────────────────────────────────────────────────────
@@ -36,6 +38,7 @@ export function DataTable({
   emptyMessage = 'Nenhum dado disponível',
   maxHeight,
   mobileMode = 'cards',
+  rowKey,
 }: DataTableProps) {
   const [sortCol, setSortCol] = useState<string>(defaultSortKey ?? columns[0]?.key ?? '')
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>(defaultSortDir)
@@ -110,7 +113,7 @@ export function DataTable({
       ) : (
         sorted.map((row, i) => (
           <DataTableRow
-            key={i}
+            key={rowKey ? String(row[rowKey]) : i}
             row={row}
             columns={columns}
             index={i}
@@ -175,14 +178,16 @@ export function DataTable({
 
           return (
             <div
-              key={i}
+              key={rowKey ? String(row[rowKey]) : i}
+              className="row-cascade"
               onClick={onRowClick ? () => onRowClick(row) : undefined}
               style={{
+                '--row-delay': `${Math.min(i, 9) * 40}ms`,
                 background: 'var(--white)', border: '1px solid #ECECE9',
                 borderRadius: 12, padding: 14, marginBottom: 10,
                 boxShadow: 'var(--shadow-md)',
                 cursor: onRowClick ? 'pointer' : 'default',
-              }}
+              } as React.CSSProperties}
             >
               <div style={{ fontWeight: 800, fontSize: 15, color: 'var(--black)', marginBottom: restCols.length ? 10 : 0 }}>
                 {firstDisplay}
@@ -257,18 +262,18 @@ function DataTableRow({
 
   return (
     <tr
+      className="row-cascade"
       onMouseEnter={() => setHov(true)}
       onMouseLeave={() => setHov(false)}
       onClick={onClick ? () => onClick(row) : undefined}
       style={{
+        '--row-delay': `${Math.min(index, 9) * 40}ms`,
         borderBottom: isLast ? 'none' : '1px solid var(--gray3)',
         borderLeft: `3px solid ${hov ? 'var(--primary)' : 'transparent'}`,
         background: hov ? 'var(--primary-dim)' : 'transparent',
-        transition: 'all .18s ease',
+        transition: 'background .18s ease, border-color .18s ease',
         cursor: onClick ? 'pointer' : 'default',
-        animation: 'ai-step 0.3s ease both',
-        animationDelay: `${index * 40}ms`,
-      }}
+      } as React.CSSProperties}
     >
       {columns.map(col => {
         const value = row[col.key]

--- a/components/widgets/KpiCard.tsx
+++ b/components/widgets/KpiCard.tsx
@@ -63,10 +63,11 @@ export interface KpiCardProps {
   sub?: string
   delay?: number
   change?: number | null
+  className?: string
 }
 
 export function KpiCard({
-  label, value, format, accent = 'var(--primary)', sub, delay = 0, change,
+  label, value, format, accent = 'var(--primary)', sub, delay = 0, change, className,
 }: KpiCardProps) {
   const [hov, setHov] = useState(false)
   const counted = useCountUp(value, 750, delay)
@@ -74,6 +75,7 @@ export function KpiCard({
 
   return (
     <div
+      className={className}
       onMouseEnter={() => setHov(true)}
       onMouseLeave={() => setHov(false)}
       style={{


### PR DESCRIPTION
Pacote C: 'dados chegando' em cascata, com cuidado para não re-animar à toa.

- `.row-cascade` (reusa rowExpand) com `--row-delay` por linha, **cap em 9** (max 360ms).
- DataTable: prop `rowKey` p/ key estável → sorting reordena sem re-animar; paginação/busca remontam e animam. Aplicado em desktop e mobile cards.
- KpiCard: prop `className`; dashboard escalona os KPIs (`animate-slide-up delay-N`) e usa `rowKey="sessionId"`.
- Tabela de leads: row-cascade + cap (já usa `key={lead.id}`).
- prefers-reduced-motion desliga as cascatas.

tsc limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)