### PR TITLE
style: avatar/contraste + emojis→lucide + tokens

### DIFF
--- a/components/AIAssistant.tsx
+++ b/components/AIAssistant.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { X, ArrowUp } from 'lucide-react'
+import { SparkleIcon } from '@/components/icons/SparkleIcon'
 
 type Message = { id: number; role: 'user' | 'assistant'; content: string; streaming?: boolean }
 
@@ -228,7 +229,9 @@ export function AIAssistant() {
           ><X size={10} /></button>
 
           {/* Spark icon */}
-          <div style={{ fontSize: 18, marginBottom: 7, lineHeight: 1 }}>✦</div>
+          <div style={{ marginBottom: 7, lineHeight: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <SparkleIcon size={18} />
+          </div>
 
           <div style={{ fontSize: 12, fontWeight: 700, lineHeight: 1.45, marginBottom: 8 }}>
             Pergunte à IA sobre seus dados!
@@ -305,11 +308,11 @@ export function AIAssistant() {
             width: 34, height: 34, borderRadius: '50%',
             background: 'var(--primary)',
             display: 'flex', alignItems: 'center', justifyContent: 'center',
-            fontSize: 15, color: 'var(--primary-contrast)',
+            color: 'var(--primary-contrast)',
             boxShadow: '0 2px 8px rgba(255,180,0,0.4)',
             animation: 'spin-slow 24s linear infinite',
             flexShrink: 0,
-          }}>✦</div>
+          }}><SparkleIcon size={15} /></div>
           <div style={{ flex: 1, minWidth: 0 }}>
             <div style={{ fontSize: 13, fontWeight: 800, color: 'var(--black)' }}>Assistente IA</div>
             <div style={{ fontSize: 10, color: 'var(--gray)', fontWeight: 500, display: 'flex', alignItems: 'center', gap: 4 }}>
@@ -465,7 +468,7 @@ function FABButton({ open, onClick }: { open: boolean; onClick: () => void }) {
         transition: 'transform 0.35s cubic-bezier(0.34,1.4,0.64,1)',
         transform: open ? 'rotate(135deg) scale(0.9)' : 'rotate(0deg) scale(1)',
       }}>
-        {open ? '✕' : '✦'}
+        {open ? <X size={16} strokeWidth={2.5} /> : <SparkleIcon size={16} />}
       </span>
     </button>
   )

--- a/components/layout/Topbar.tsx
+++ b/components/layout/Topbar.tsx
@@ -94,7 +94,7 @@ export function Topbar({ userName, userRole, brandName, logoUrl }: TopbarProps) 
             style={{
               width: 34, height: 34, borderRadius: 100, background: 'var(--primary)',
               display: 'flex', alignItems: 'center', justifyContent: 'center',
-              fontSize: 12, fontWeight: 800, color: 'var(--black)', cursor: 'pointer',
+              fontSize: 12, fontWeight: 800, color: 'var(--primary-contrast)', cursor: 'pointer',
               overflow: 'hidden',
             }}
           >

--- a/components/widgets/DataTable.tsx
+++ b/components/widgets/DataTable.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState } from 'react'
+import { ChevronUp, ChevronDown } from 'lucide-react'
 import { useIsMobile } from '@/lib/hooks/useMediaQuery'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -89,9 +90,9 @@ export function DataTable({
               <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3, flexDirection: align === 'right' ? 'row-reverse' : 'row' }}>
                 {col.label}
                 {col.sortable !== false && (
-                  <span style={{ display: 'inline-flex', flexDirection: 'column', gap: 1, opacity: active ? 1 : 0.3, transition: 'opacity .15s' }}>
-                    <span style={{ fontSize: 7, lineHeight: 1, color: active && sortDir === 'asc' ? 'var(--primary-text)' : 'currentColor' }}>▲</span>
-                    <span style={{ fontSize: 7, lineHeight: 1, color: active && sortDir === 'desc' ? 'var(--primary-text)' : 'currentColor' }}>▼</span>
+                  <span style={{ display: 'inline-flex', flexDirection: 'column', gap: 0, opacity: active ? 1 : 0.3, transition: 'opacity .15s' }}>
+                    <ChevronUp size={9} style={{ display: 'block', color: active && sortDir === 'asc' ? 'var(--primary-text)' : 'currentColor' }} />
+                    <ChevronDown size={9} style={{ display: 'block', color: active && sortDir === 'desc' ? 'var(--primary-text)' : 'currentColor' }} />
                   </span>
                 )}
               </span>
@@ -158,7 +159,7 @@ export function DataTable({
                   }}
                 >
                   {col.label}
-                  {active && <span style={{ fontSize: 9 }}>{sortDir === 'asc' ? '▲' : '▼'}</span>}
+                  {active && (sortDir === 'asc' ? <ChevronUp size={9} /> : <ChevronDown size={9} />)}
                 </button>
               )
             })}
@@ -183,7 +184,7 @@ export function DataTable({
               onClick={onRowClick ? () => onRowClick(row) : undefined}
               style={{
                 '--row-delay': `${Math.min(i, 9) * 40}ms`,
-                background: 'var(--white)', border: '1px solid #ECECE9',
+                background: 'var(--white)', border: '1px solid var(--line)',
                 borderRadius: 12, padding: 14, marginBottom: 10,
                 boxShadow: 'var(--shadow-md)',
                 cursor: onRowClick ? 'pointer' : 'default',

--- a/components/widgets/FunnelChart.tsx
+++ b/components/widgets/FunnelChart.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { Clock, ArrowRight, ArrowUp, ArrowDown } from 'lucide-react'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -212,8 +213,8 @@ export function FunnelChart({ allStages, stages, visible, ready, unit = 'lead' }
                 <div style={{ fontWeight: 700, marginBottom: 1, opacity: 0.7, fontSize: 10 }}>{segs[hov].name}</div>
                 <div>{segs[hov].count} {unit}{segs[hov].count !== 1 ? 's' : ''}</div>
                 {segs[hov].avgDays != null && (
-                  <div style={{ fontSize: 10, fontWeight: 600, opacity: 0.75, marginTop: 2 }}>
-                    ⏱ {segs[hov].avgDays} dias médios
+                  <div style={{ fontSize: 10, fontWeight: 600, opacity: 0.75, marginTop: 2, display: 'flex', alignItems: 'center', gap: 3 }}>
+                    <Clock size={11} /> {segs[hov].avgDays} dias médios
                   </div>
                 )}
               </div>
@@ -226,7 +227,7 @@ export function FunnelChart({ allStages, stages, visible, ready, unit = 'lead' }
                 : seg.dropPct < 0 ? 'var(--red)'
                 : seg.dropPct > 0 ? 'var(--green)'
                 : 'var(--gray2)'
-              const dropArrow = seg.dropPct === null || seg.dropPct === 0 ? '→' : seg.dropPct > 0 ? '↑' : '↓'
+              const DropArrow = seg.dropPct === null || seg.dropPct === 0 ? ArrowRight : seg.dropPct > 0 ? ArrowUp : ArrowDown
               const badgeBg   = seg.dropPct === null ? 'transparent'
                 : seg.dropPct < 0 ? 'rgba(217,48,37,0.08)'
                 : seg.dropPct > 0 ? 'rgba(30,138,62,0.08)'
@@ -276,7 +277,7 @@ export function FunnelChart({ allStages, stages, visible, ready, unit = 'lead' }
                       opacity: showPct ? 1 : 0,
                       transition: 'opacity 0.2s ease',
                     }}>
-                      {dropArrow} {Math.abs(seg.dropPct ?? 0)}%
+                      <DropArrow size={8} /> {Math.abs(seg.dropPct ?? 0)}%
                     </span>
                   </div>
 
@@ -287,8 +288,9 @@ export function FunnelChart({ allStages, stages, visible, ready, unit = 'lead' }
                       transition: 'color 0.15s',
                       marginTop: 1,
                       textAlign: 'center',
+                      display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 2,
                     }}>
-                      ⏱ {seg.avgDays}d
+                      <Clock size={10} /> {seg.avgDays}d
                     </div>
                   )}
                 </div>

--- a/components/widgets/KpiCard.tsx
+++ b/components/widgets/KpiCard.tsx
@@ -80,7 +80,7 @@ export function KpiCard({
       onMouseLeave={() => setHov(false)}
       style={{
         background: 'var(--white)',
-        border: '1px solid #ECECE9',
+        border: '1px solid var(--line)',
         borderLeft: `4px solid ${accent}`,
         borderRadius: 12,
         padding: '18px 20px',


### PR DESCRIPTION
Quick wins de design (Fase 0): contraste do avatar (var(--primary-contrast)), emojis dos widgets → ícones lucide/SparkleIcon, e bordas #ECECE9 → var(--line). tsc limpo.

(Follow-up: ainda há emojis ✕/✦ em dashboard/ranking/pipeline/conversas — tratados num PR à parte.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)