### PR TITLE
style: emojis restantes → ícones (X/SparkleIcon)

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { BarChart3, Settings } from 'lucide-react'
+import { SparkleIcon } from '@/components/icons/SparkleIcon'
 import { KpiCard } from '@/components/widgets/KpiCard'
 import { FunnelChart, FunnelFilterPanel } from '@/components/widgets/FunnelChart'
 import type { FunnelStage } from '@/components/widgets/FunnelChart'
@@ -113,7 +114,7 @@ function AskAIButton({ question }: { question: string }) {
         transition: 'all 0.18s cubic-bezier(0.34,1.4,0.64,1)',
       }}
     >
-      <span style={{ fontSize: 9 }}>✦</span> Analisar
+      <SparkleIcon size={9} /> Analisar
     </button>
   )
 }

--- a/app/(app)/dashboard/ranking/page.tsx
+++ b/app/(app)/dashboard/ranking/page.tsx
@@ -1,7 +1,9 @@
 'use client'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useEffect, useState, useRef } from 'react'
+import { X } from 'lucide-react'
 import { formatCurrency } from '@/lib/utils'
+import { SparkleIcon } from '@/components/icons/SparkleIcon'
 
 type Period = 'all' | '7d' | '30d' | '90d'
 type Metric = 'revenue' | 'won' | 'conversion'
@@ -164,7 +166,7 @@ function TeamsModal({ allReps, onClose }: { allReps: string[]; onClose: () => vo
               </div>
             </div>
           </div>
-          <button onClick={onClose} style={{ width: 32, height: 32, borderRadius: 8, border: 'none', background: 'var(--bg)', cursor: 'pointer', fontSize: 16, color: 'var(--gray2)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>✕</button>
+          <button onClick={onClose} aria-label="Fechar" style={{ width: 32, height: 32, borderRadius: 8, border: 'none', background: 'var(--bg)', cursor: 'pointer', color: 'var(--gray2)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><X size={14} /></button>
         </div>
 
         {/* Modal body */}
@@ -191,7 +193,7 @@ function TeamsModal({ allReps, onClose }: { allReps: string[]; onClose: () => vo
                     {t.members.length} {t.members.length === 1 ? 'membro' : 'membros'}
                   </span>
                   <button onClick={() => openEdit(t)} style={{ padding: '6px 12px', borderRadius: 8, border: '1px solid var(--gray3)', background: 'var(--white)', fontSize: 12, fontWeight: 600, color: 'var(--gray)', cursor: 'pointer' }}>Editar</button>
-                  <button onClick={() => deleteTeam(t)} style={{ padding: '6px 10px', borderRadius: 8, border: '1px solid rgba(217,48,37,0.2)', background: 'rgba(217,48,37,0.06)', fontSize: 12, fontWeight: 600, color: 'var(--red)', cursor: 'pointer' }}>✕</button>
+                  <button onClick={() => deleteTeam(t)} aria-label="Excluir time" style={{ padding: '6px 10px', borderRadius: 8, border: '1px solid rgba(217,48,37,0.2)', background: 'rgba(217,48,37,0.06)', color: 'var(--red)', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><X size={12} /></button>
                 </div>
               ))}
             </div>
@@ -930,8 +932,8 @@ export default function RankingPage() {
               }} />
             ))}
 
-            <div style={{ fontSize: 9, fontWeight: 800, textTransform: 'uppercase', letterSpacing: '0.14em', color: 'var(--gray2)', marginBottom: 24, position: 'relative' }}>
-              ✦ Pódio
+            <div style={{ fontSize: 9, fontWeight: 800, textTransform: 'uppercase', letterSpacing: '0.14em', color: 'var(--gray2)', marginBottom: 24, position: 'relative', display: 'flex', alignItems: 'center', gap: 4 }}>
+              <SparkleIcon size={9} /> Pódio
             </div>
 
             {/* Cards */}

--- a/app/(app)/pipeline/page.tsx
+++ b/app/(app)/pipeline/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
+import { X } from 'lucide-react'
 import { formatCurrency, daysAgo } from '@/lib/utils'
 
 type Priority = 'high' | 'normal' | 'low'
@@ -49,7 +50,7 @@ function LeadExtrasPanel({ lead, onClose, onSave }: { lead: any; onClose: () => 
                 {lead.stage?.name} · {lead.responsibleName}
               </div>
             </div>
-            <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--gray2)', fontSize: 18, lineHeight: 1 }}>✕</button>
+            <button onClick={onClose} aria-label="Fechar" style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--gray2)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><X size={16} /></button>
           </div>
           <div style={{ fontSize: 18, fontWeight: 800, color: 'var(--green)', marginTop: 8 }}>
             {formatCurrency(lead.price)}
@@ -88,8 +89,8 @@ function LeadExtrasPanel({ lead, onClose, onSave }: { lead: any; onClose: () => 
                   background: 'var(--primary-dim)', border: '1px solid var(--primary-mid)', color: 'var(--primary-text)',
                 }}>
                   {tag}
-                  <button onClick={() => setTags(tags.filter(t => t !== tag))}
-                    style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--primary-text)', lineHeight: 1, padding: 0, fontSize: 12 }}>✕</button>
+                  <button onClick={() => setTags(tags.filter(t => t !== tag))} aria-label="Remover tag"
+                    style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--primary-text)', padding: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}><X size={10} /></button>
                 </span>
               ))}
             </div>
@@ -355,7 +356,7 @@ export default function PipelinePage() {
               onMouseEnter={e => (e.currentTarget.style.color = 'var(--red)')}
               onMouseLeave={e => (e.currentTarget.style.color = 'var(--gray2)')}
             >
-              ✕ Limpar
+              <X size={12} /> Limpar
             </button>
           )}
         </div>

--- a/app/(app)/sdr-ia/conversas/page.tsx
+++ b/app/(app)/sdr-ia/conversas/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { useSearchParams } from 'next/navigation'
 import type { CSSProperties } from 'react'
+import { X } from 'lucide-react'
 import { timeAgo } from '@/lib/format'
 import { Skeleton, SkeletonSessionList } from '@/components/Skeleton'
 
@@ -797,7 +798,8 @@ export default function ConversasPage() {
                       fontSize: 10, fontWeight: 700, padding: '3px 10px', borderRadius: 99,
                       background: 'rgba(180,50,0,0.06)', color: '#9a2008',
                       border: '1px solid rgba(180,50,0,0.18)',
-                    }}>✕ Janela encerrada</span>
+                      display: 'inline-flex', alignItems: 'center', gap: 3,
+                    }}><X size={9} /> Janela encerrada</span>
                   )}
                 </div>
               </>


### PR DESCRIPTION
Fecha a varredura de emoji: ✕ → <X> (aria-label nos icon-only) e ✦ → SparkleIcon em dashboard, ranking, pipeline e conversas. Grep de emoji limpo. tsc limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)