### PR TITLE
fix: ack do disparo passa pelo middleware (307→handler)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -15,7 +15,8 @@ export default auth((req) => {
     pathname.startsWith('/forgot-password') ||
     pathname.startsWith('/reset-password') ||
     pathname.startsWith('/api/auth') ||
-    pathname.startsWith('/api/webhooks/')
+    pathname.startsWith('/api/webhooks/') ||
+    pathname === '/api/sdr/blast/ack' // server-to-server (n8n); autentica via Bearer próprio
 
   // 1. Master on /login → /master
   if (isLoggedIn && isMaster && pathname === '/login') {


### PR DESCRIPTION
O endpoint `/api/sdr/blast/ack` (chamado pelo n8n, server-to-server) estava tomando 307→/login no middleware antes de chegar no handler — os destinatários ficavam em 'pendente' com `ycloud_message_id` nulo. Adiciona a rota ao `isPublic` (ela já valida o Bearer = n8nBlastSecret, como os webhooks).

Descoberto no disparo de teste: mensagem entregue (eventos whatsapp_status_*), mas o ack não gravava.

🤖 Generated with [Claude Code](https://claude.com/claude-code)