### PR TITLE
feat: gating de papel no front (esconde disparo p/ user)

### DIFF
--- a/app/(app)/sdr-ia/leads/page.tsx
+++ b/app/(app)/sdr-ia/leads/page.tsx
@@ -4,6 +4,7 @@ import { Search } from 'lucide-react'
 import { SkeletonTable } from '@/components/Skeleton'
 import { Button } from '@/components/ui/Button'
 import { useCountUp } from '@/components/widgets/KpiCard'
+import { useCanDispatch } from '@/lib/hooks/useCanDispatch'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -145,6 +146,8 @@ export default function LeadsPage() {
   const masterRef           = useRef<HTMLInputElement>(null)
   const fileInputRef        = useRef<HTMLInputElement>(null)
   const templateDropdownRef = useRef<HTMLDivElement>(null)
+
+  const { canDispatch } = useCanDispatch()
 
   // Debounce search
   useEffect(() => {
@@ -638,13 +641,15 @@ export default function LeadsPage() {
         display: 'flex', alignItems: 'center', gap: 14,
         marginBottom: 16, flexWrap: 'wrap' as const,
       }}>
-        <Button
-          variant="primary"
-          onClick={enroll}
-          disabled={enrolling || selected.size === 0}
-        >
-          {enrolling ? 'Adicionando...' : `Adicionar à campanha${selected.size > 0 ? ` (${selected.size})` : ''}`}
-        </Button>
+        {canDispatch && (
+          <Button
+            variant="primary"
+            onClick={enroll}
+            disabled={enrolling || selected.size === 0}
+          >
+            {enrolling ? 'Adicionando...' : `Adicionar à campanha${selected.size > 0 ? ` (${selected.size})` : ''}`}
+          </Button>
+        )}
 
         {enrollResult?.ok && (
           <span style={{ fontSize: 13, fontWeight: 700, color: 'var(--green)' }}>
@@ -898,7 +903,7 @@ export default function LeadsPage() {
                     {campaignEnrollResult ? 'Fechar' : 'Só manter na lista'}
                   </Button>
 
-                  {!campaignEnrollResult && (
+                  {!campaignEnrollResult && canDispatch && (
                     <>
                       <Button
                         variant="secondary"
@@ -1125,14 +1130,16 @@ export default function LeadsPage() {
                       >
                         Cancelar
                       </Button>
-                      <Button
-                        variant="primary"
-                        className={blasting ? 'btn-pulse' : undefined}
-                        onClick={runBlast}
-                        disabled={blasting}
-                      >
-                        Confirmar disparo
-                      </Button>
+                      {canDispatch && (
+                        <Button
+                          variant="primary"
+                          className={blasting ? 'btn-pulse' : undefined}
+                          onClick={runBlast}
+                          disabled={blasting}
+                        >
+                          Confirmar disparo
+                        </Button>
+                      )}
                     </>
                   ) : (
                     <>
@@ -1146,7 +1153,7 @@ export default function LeadsPage() {
                       >
                         {blastResult ? 'Fechar' : 'Voltar'}
                       </Button>
-                      {!blastResult && (
+                      {!blastResult && canDispatch && (
                         <Button
                           variant="primary"
                           className={blasting ? 'btn-pulse' : undefined}

--- a/app/(app)/settings/integrations/credenciais/page.tsx
+++ b/app/(app)/settings/integrations/credenciais/page.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { Eye, EyeOff } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
+import { useCanDispatch } from '@/lib/hooks/useCanDispatch'
 
 // ─── SecretInput ──────────────────────────────────────────────────────────────
 
@@ -132,6 +133,8 @@ function Card({ title, children }: { title: string; children: React.ReactNode })
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function CredenciaisPage() {
+  const { canDispatch } = useCanDispatch()
+
   // full settings from GET — preserved and re-sent on PUT so campaign fields aren't zeroed
   const [fullSettings, setFullSettings]     = useState<Record<string, unknown>>({})
   const [fullStatus,   setFullStatus]       = useState<string>('draft')
@@ -301,13 +304,15 @@ export default function CredenciaisPage() {
           />
 
           <div style={{ display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap' as const }}>
-            <Button
-              variant="primary"
-              onClick={dispatch}
-              disabled={dispatching || !n8nDispatchUrl}
-            >
-              {dispatching ? 'Disparando...' : 'Disparar agora'}
-            </Button>
+            {canDispatch && (
+              <Button
+                variant="primary"
+                onClick={dispatch}
+                disabled={dispatching || !n8nDispatchUrl}
+              >
+                {dispatching ? 'Disparando...' : 'Disparar agora'}
+              </Button>
+            )}
 
             {dispatchResult !== undefined && dispatchResult.ok && (
               <div style={{

--- a/lib/hooks/useCanDispatch.ts
+++ b/lib/hooks/useCanDispatch.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query'
+
+interface MeData { user?: { role?: string } }
+
+const DISPATCH_ROLES = ['master', 'admin', 'manager']
+
+/**
+ * Returns whether the current user has permission to trigger WhatsApp sends
+ * (blast / enroll / dispatch). Reuses the shared ['me'] cache so there is
+ * no extra network request when the settings page has already fetched it.
+ *
+ * Defaults to false while loading — intentionally fail-closed for a
+ * permission check.
+ */
+export function useCanDispatch(): { canDispatch: boolean } {
+  const { data } = useQuery<MeData>({
+    queryKey: ['me'],
+    queryFn:  () => fetch('/api/me').then(r => r.json()),
+    staleTime: 5 * 60 * 1000,
+  })
+  return { canDispatch: DISPATCH_ROLES.includes(data?.user?.role ?? '') }
+}


### PR DESCRIPTION
Fase 1a (5/6): espelho do requireRole no front.

- `lib/hooks/useCanDispatch.ts`: fonte única, reusa o cache `['me']` (sem fetch extra), **fail-closed**, só master/admin/manager.
- Esconde blast + enroll na tela de Leads e "Disparar agora" no Credenciais quando `!canDispatch`. 'user' segue vendo todos os dados.

tsc limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)