### PR TITLE
feat: CSV + reenviar falhas (fecha Fase 1a)

### DIFF
--- a/app/(app)/sdr-ia/disparos/page.tsx
+++ b/app/(app)/sdr-ia/disparos/page.tsx
@@ -1,14 +1,17 @@
 'use client'
 import { useState, useCallback } from 'react'
-import { ArrowLeft, RefreshCw } from 'lucide-react'
+import { ArrowLeft, RefreshCw, Download, RotateCcw } from 'lucide-react'
 import { Skeleton } from '@/components/Skeleton'
+import { Button } from '@/components/ui/Button'
 import { useQuery } from '@tanstack/react-query'
+import { useCanDispatch } from '@/lib/hooks/useCanDispatch'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 interface Campaign {
   id:              string
   template:        string
+  templateBody:    string | null
   totalSolicitado: number
   skipped:         number
   started:         number
@@ -35,15 +38,17 @@ interface Recipient {
 }
 
 interface DetailResponse {
-  campaign:    Campaign
-  recipients:  Recipient[]
+  campaign:   Campaign
+  recipients: Recipient[]
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function fmtDate(ts: number | null): string {
   if (!ts) return '—'
-  return new Date(ts * 1000).toLocaleString('pt-BR', { day: '2-digit', month: '2-digit', year: '2-digit', hour: '2-digit', minute: '2-digit' })
+  return new Date(ts * 1000).toLocaleString('pt-BR', {
+    day: '2-digit', month: '2-digit', year: '2-digit', hour: '2-digit', minute: '2-digit',
+  })
 }
 
 function fmtPhone(phone: string): string {
@@ -54,15 +59,21 @@ function fmtPhone(phone: string): string {
   return phone
 }
 
+// RFC-4180 compliant CSV field: always wrap in double-quotes, double internal quotes.
+function csvField(s: string): string {
+  return '"' + String(s ?? '').replace(/"/g, '""') + '"'
+}
+
 const STATUS_LABEL: Record<string, string> = {
   pendente: 'Pendente', enviado: 'Enviado', entregue: 'Entregue', lido: 'Lido', falhou: 'Falhou',
 }
+
 const STATUS_COLOR: Record<string, { dot: string; text: string; bg: string; border: string }> = {
-  pendente: { dot: 'var(--gray3)',  text: 'var(--gray2)',   bg: 'var(--bg)',             border: 'var(--gray3)'                },
-  enviado:  { dot: '#60a5fa',       text: '#1d4ed8',        bg: 'rgba(59,130,246,0.07)', border: 'rgba(59,130,246,0.25)'       },
-  entregue: { dot: 'var(--primary)', text: 'var(--primary-text)', bg: 'var(--primary-dim)', border: 'var(--primary-mid)'       },
-  lido:     { dot: 'var(--green)',  text: 'var(--green)',   bg: 'rgba(30,138,62,0.07)',  border: 'rgba(30,138,62,0.22)'        },
-  falhou:   { dot: 'var(--red)',    text: 'var(--red)',     bg: 'rgba(217,48,37,0.07)',  border: 'rgba(217,48,37,0.20)'        },
+  pendente: { dot: 'var(--gray3)',  text: 'var(--gray2)',   bg: 'var(--bg)',             border: 'var(--gray3)'          },
+  enviado:  { dot: '#60a5fa',       text: '#1d4ed8',        bg: 'rgba(59,130,246,0.07)', border: 'rgba(59,130,246,0.25)' },
+  entregue: { dot: 'var(--primary)', text: 'var(--primary-text)', bg: 'var(--primary-dim)', border: 'var(--primary-mid)' },
+  lido:     { dot: 'var(--green)',  text: 'var(--green)',   bg: 'rgba(30,138,62,0.07)',  border: 'rgba(30,138,62,0.22)'  },
+  falhou:   { dot: 'var(--red)',    text: 'var(--red)',     bg: 'rgba(217,48,37,0.07)',  border: 'rgba(217,48,37,0.20)'  },
 }
 
 function StatusBadge({ status }: { status: string }) {
@@ -81,16 +92,12 @@ function StatusBadge({ status }: { status: string }) {
 
 function CampaignStatusBadge({ status }: { status: string }) {
   const map: Record<string, { label: string; color: string }> = {
-    enviando: { label: 'Em andamento', color: '#d97706' },
-    concluido: { label: 'Concluído',   color: 'var(--green)' },
-    erro:      { label: 'Erro',        color: 'var(--red)' },
+    enviando:  { label: 'Em andamento', color: '#d97706'       },
+    concluido: { label: 'Concluído',    color: 'var(--green)'  },
+    erro:      { label: 'Erro',         color: 'var(--red)'    },
   }
   const s = map[status] ?? { label: status, color: 'var(--gray2)' }
-  return (
-    <span style={{ fontSize: 11, fontWeight: 700, color: s.color }}>
-      {s.label}
-    </span>
-  )
+  return <span style={{ fontSize: 11, fontWeight: 700, color: s.color }}>{s.label}</span>
 }
 
 function MetricPill({ label, value, color }: { label: string; value: number; color: string }) {
@@ -102,70 +109,116 @@ function MetricPill({ label, value, color }: { label: string; value: number; col
   )
 }
 
-// ─── List view ────────────────────────────────────────────────────────────────
+// ─── Pill button (shared look for Exportar / Atualizar) ───────────────────────
 
-function CampaignRow({ c, onClick }: { c: Campaign; onClick: () => void }) {
+function PillBtn({
+  onClick, icon, label, disabled,
+}: { onClick: () => void; icon: React.ReactNode; label: string; disabled?: boolean }) {
   return (
-    <div
+    <button
       onClick={onClick}
+      disabled={disabled}
       style={{
-        display: 'flex', alignItems: 'center', gap: 16,
-        padding: '14px 16px', cursor: 'pointer',
-        borderBottom: '1px solid var(--gray3)',
-        transition: 'background .12s',
+        display: 'flex', alignItems: 'center', gap: 6,
+        padding: '7px 14px', borderRadius: 100,
+        border: '1px solid var(--gray3)', background: 'var(--white)',
+        fontSize: 12, fontWeight: 700, color: disabled ? 'var(--gray3)' : 'var(--gray)',
+        cursor: disabled ? 'not-allowed' : 'pointer', transition: 'background .15s',
       }}
-      onMouseEnter={e => (e.currentTarget.style.background = 'var(--bg)')}
-      onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+      onMouseEnter={e => { if (!disabled) (e.currentTarget as HTMLButtonElement).style.background = 'var(--bg)' }}
+      onMouseLeave={e => { if (!disabled) (e.currentTarget as HTMLButtonElement).style.background = 'var(--white)' }}
     >
-      {/* Left: template + meta */}
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--black)', marginBottom: 3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-          {c.template}
-        </div>
-        <div style={{ fontSize: 11, color: 'var(--gray2)', fontWeight: 500, display: 'flex', gap: 10, flexWrap: 'wrap' }}>
-          <span>{fmtDate(c.createdAt)}</span>
-          {c.createdByName && <span>por {c.createdByName}</span>}
-          <CampaignStatusBadge status={c.status} />
-        </div>
-      </div>
-
-      {/* Metrics */}
-      <div style={{ display: 'flex', gap: 20, alignItems: 'center', flexShrink: 0 }}>
-        <MetricPill label="Total"    value={c.totalSolicitado} color="var(--ink)"     />
-        <MetricPill label="Enviado"  value={c.enviado}         color="#1d4ed8"         />
-        <MetricPill label="Entregue" value={c.entregue}        color="var(--primary-text)" />
-        <MetricPill label="Lido"     value={c.lido}            color="var(--green)"    />
-        <MetricPill label="Falhou"   value={c.falhou}          color="var(--red)"      />
-      </div>
-
-      <div style={{ fontSize: 12, color: 'var(--gray2)', flexShrink: 0 }}>›</div>
-    </div>
+      {icon} {label}
+    </button>
   )
 }
 
 // ─── Detail view ──────────────────────────────────────────────────────────────
 
-function DetailView({ campaignId, onBack, onRefresh }: { campaignId: string; onBack: () => void; onRefresh: () => void }) {
+function DetailView({ campaignId, onBack }: { campaignId: string; onBack: () => void }) {
+  const { canDispatch } = useCanDispatch()
   const [key, setKey] = useState(0)
   const { data, isLoading, isError, refetch } = useQuery<DetailResponse>({
     queryKey: ['blast-detail', campaignId, key],
-    queryFn: () => fetch(`/api/sdr/blast/campaigns/${campaignId}`).then(r => r.json()),
+    queryFn:  () => fetch(`/api/sdr/blast/campaigns/${campaignId}`).then(r => r.json()),
     staleTime: 0,
   })
 
-  function refresh() { setKey(k => k + 1); onRefresh() }
+  // ── Re-send state ────────────────────────────────────────────────────────────
+  const [reenvioMode,    setReenvioMode]    = useState<'idle' | 'confirm' | 'sending' | 'done'>('idle')
+  const [reenvioResult,  setReenvioResult]  = useState<{ ok: boolean; started?: number; campaignId?: string; error?: string } | null>(null)
 
-  const c = data?.campaign
+  function refresh() { setKey(k => k + 1); setReenvioMode('idle'); setReenvioResult(null) }
+
+  // ── CSV export ───────────────────────────────────────────────────────────────
+  function exportCsv() {
+    if (!data) return
+    const { campaign: c, recipients } = data
+    const header = ['Nome', 'Telefone', 'Status', 'Motivo'].map(csvField).join(';')
+    const rows = recipients.map(r => [
+      r.firstName,
+      r.phone,
+      STATUS_LABEL[r.status] ?? r.status,
+      r.errorReason ?? (r.status === 'falhou' ? 'Erro desconhecido' : ''),
+    ].map(csvField).join(';'))
+    const csv = '﻿' + [header, ...rows].join('\r\n') // BOM + CRLF for Excel/Windows
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+    const url  = URL.createObjectURL(blob)
+    const a    = document.createElement('a')
+    a.href     = url
+    a.download = `disparo-${c.template.replace(/[^a-z0-9]/gi, '-').toLowerCase()}-${campaignId.slice(0, 8)}.csv`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  }
+
+  // ── Re-send failed ───────────────────────────────────────────────────────────
+  async function reenviar() {
+    if (!data) return
+    const { campaign: c, recipients } = data
+    const failed = recipients.filter(r => r.status === 'falhou')
+    if (failed.length === 0) return
+
+    setReenvioMode('sending')
+    try {
+      const names: Record<string, string> = {}
+      failed.forEach(r => { names[r.leadId] = r.firstName })
+
+      const res  = await fetch('/api/sdr/leads/blast', {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify({
+          leadIds:      failed.map(r => r.leadId),
+          template:     c.template,
+          templateBody: c.templateBody ?? undefined,
+          names,
+        }),
+      })
+      const body = await res.json() as { ok: boolean; started?: number; campaignId?: string; error?: string }
+      setReenvioResult(body)
+      setReenvioMode('done')
+    } catch (e) {
+      setReenvioResult({ ok: false, error: (e as Error).message })
+      setReenvioMode('done')
+    }
+  }
+
+  const c          = data?.campaign
   const recipients = data?.recipients ?? []
-  const total = recipients.length
-  const bySt = Object.fromEntries(
-    (['pendente','enviado','entregue','lido','falhou'] as const).map(s => [s, recipients.filter(r => r.status === s).length])
+  const total      = recipients.length
+  const bySt       = Object.fromEntries(
+    (['pendente', 'enviado', 'entregue', 'lido', 'falhou'] as const).map(s => [
+      s, recipients.filter(r => r.status === s).length,
+    ]),
   )
+  const failedCount   = bySt.falhou ?? 0
+  const showReenvio   = canDispatch && failedCount > 0 && c != null
 
   return (
     <div>
-      {/* Header */}
-      <div className="animate-slide-up delay-1" style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 24 }}>
+      {/* ── Header ──────────────────────────────────────────────────────────── */}
+      <div className="animate-slide-up delay-1" style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 24, flexWrap: 'wrap' }}>
         <button
           onClick={onBack}
           style={{ display: 'flex', alignItems: 'center', gap: 6, background: 'none', border: 'none', cursor: 'pointer', color: 'var(--gray2)', fontSize: 13, fontWeight: 600, padding: 0 }}
@@ -173,58 +226,145 @@ function DetailView({ campaignId, onBack, onRefresh }: { campaignId: string; onB
           <ArrowLeft size={14} /> Disparos
         </button>
         <span style={{ color: 'var(--gray3)', fontWeight: 300 }}>/</span>
-        <span style={{ fontSize: 13, color: 'var(--gray)', fontWeight: 600, maxWidth: 300, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        <span style={{ fontSize: 13, color: 'var(--gray)', fontWeight: 600, maxWidth: 260, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
           {isLoading ? '…' : (c?.template ?? 'Campanha')}
         </span>
+
         <div style={{ flex: 1 }} />
-        <button
+
+        <PillBtn
+          onClick={exportCsv}
+          icon={<Download size={12} />}
+          label="Exportar CSV"
+          disabled={!c || recipients.length === 0}
+        />
+        {showReenvio && reenvioMode === 'idle' && (
+          <PillBtn
+            onClick={() => setReenvioMode('confirm')}
+            icon={<RotateCcw size={12} />}
+            label={`Reenviar falhas (${failedCount})`}
+          />
+        )}
+        <PillBtn
           onClick={refresh}
-          style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 14px', borderRadius: 100, border: '1px solid var(--gray3)', background: 'var(--white)', fontSize: 12, fontWeight: 700, color: 'var(--gray)', cursor: 'pointer', transition: 'background .15s' }}
-          onMouseEnter={e => (e.currentTarget.style.background = 'var(--bg)')}
-          onMouseLeave={e => (e.currentTarget.style.background = 'var(--white)')}
-        >
-          <RefreshCw size={12} /> Atualizar
-        </button>
+          icon={<RefreshCw size={12} />}
+          label="Atualizar"
+        />
       </div>
 
+      {/* ── Loading ──────────────────────────────────────────────────────────── */}
       {isLoading && (
         <div className="animate-slide-up delay-2" style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
           {[...Array(5)].map((_, i) => <Skeleton key={i} height={52} radius={10} />)}
         </div>
       )}
 
+      {/* ── Error ────────────────────────────────────────────────────────────── */}
       {isError && (
         <div className="animate-slide-up delay-2" style={{ padding: 24, textAlign: 'center', color: 'var(--red)', fontSize: 13 }}>
-          Erro ao carregar. <button onClick={() => refetch()} style={{ background: 'none', border: 'none', color: 'var(--primary-text)', fontWeight: 700, cursor: 'pointer' }}>Tentar novamente</button>
+          Erro ao carregar.{' '}
+          <button onClick={() => refetch()} style={{ background: 'none', border: 'none', color: 'var(--primary-text)', fontWeight: 700, cursor: 'pointer' }}>
+            Tentar novamente
+          </button>
         </div>
       )}
 
       {c && (
         <>
-          {/* Campaign summary */}
-          <div className="animate-slide-up delay-2" style={{ background: 'var(--white)', border: '1px solid var(--gray3)', borderRadius: 14, padding: '16px 20px', marginBottom: 18, display: 'flex', gap: 24, flexWrap: 'wrap', alignItems: 'center' }}>
+          {/* ── Campaign summary ─────────────────────────────────────────────── */}
+          <div className="animate-slide-up delay-2" style={{
+            background: 'var(--white)', border: '1px solid var(--gray3)', borderRadius: 14,
+            padding: '16px 20px', marginBottom: 18,
+            display: 'flex', gap: 24, flexWrap: 'wrap', alignItems: 'center',
+          }}>
             <div style={{ flex: 1, minWidth: 0 }}>
               <div style={{ fontSize: 15, fontWeight: 800, color: 'var(--black)', marginBottom: 4 }}>{c.template}</div>
-              <div style={{ fontSize: 12, color: 'var(--gray2)' }}>{fmtDate(c.createdAt)}{c.createdByName ? ` · por ${c.createdByName}` : ''}</div>
+              <div style={{ fontSize: 12, color: 'var(--gray2)' }}>
+                {fmtDate(c.createdAt)}{c.createdByName ? ` · por ${c.createdByName}` : ''}
+              </div>
             </div>
             <div style={{ display: 'flex', gap: 24, flexWrap: 'wrap', alignItems: 'center' }}>
-              <MetricPill label="Total"    value={total}           color="var(--ink)"         />
-              <MetricPill label="Enviado"  value={bySt.enviado}    color="#1d4ed8"             />
-              <MetricPill label="Entregue" value={bySt.entregue}   color="var(--primary-text)" />
-              <MetricPill label="Lido"     value={bySt.lido}       color="var(--green)"        />
-              <MetricPill label="Falhou"   value={bySt.falhou}     color="var(--red)"          />
+              <MetricPill label="Total"    value={total}          color="var(--ink)"          />
+              <MetricPill label="Enviado"  value={bySt.enviado}   color="#1d4ed8"              />
+              <MetricPill label="Entregue" value={bySt.entregue}  color="var(--primary-text)"  />
+              <MetricPill label="Lido"     value={bySt.lido}      color="var(--green)"         />
+              <MetricPill label="Falhou"   value={bySt.falhou}    color="var(--red)"           />
               {bySt.pendente > 0 && <MetricPill label="Pendente" value={bySt.pendente} color="var(--gray2)" />}
             </div>
             <CampaignStatusBadge status={c.status} />
           </div>
 
-          {/* Recipient table */}
+          {/* ── Re-send confirm panel ─────────────────────────────────────────── */}
+          {showReenvio && reenvioMode !== 'idle' && (
+            <div className="animate-slide-up" style={{
+              marginBottom: 18, padding: '14px 18px', borderRadius: 12,
+              background: reenvioMode === 'done' && reenvioResult?.ok
+                ? 'rgba(34,197,94,0.06)'
+                : reenvioMode === 'done'
+                  ? 'rgba(239,68,68,0.06)'
+                  : 'rgba(245,158,11,0.07)',
+              border: `1px solid ${
+                reenvioMode === 'done' && reenvioResult?.ok
+                  ? 'rgba(34,197,94,0.25)'
+                  : reenvioMode === 'done'
+                    ? 'rgba(239,68,68,0.25)'
+                    : 'rgba(245,158,11,0.30)'
+              }`,
+            }}>
+              {reenvioMode === 'confirm' && (
+                <>
+                  <div style={{ fontSize: 13, fontWeight: 700, color: '#92400e', marginBottom: 6 }}>
+                    Reenviar para {failedCount} destinatário{failedCount !== 1 ? 's' : ''} que falharam?
+                  </div>
+                  <div style={{ fontSize: 12, color: '#78350f', marginBottom: 14, lineHeight: 1.55 }}>
+                    Será criada uma nova campanha com o mesmo template <strong>{c.template}</strong>.
+                    Envio real via WhatsApp — ação irreversível.
+                  </div>
+                  <div style={{ display: 'flex', gap: 10 }}>
+                    <Button variant="ghost" onClick={() => setReenvioMode('idle')}>Cancelar</Button>
+                    <Button variant="primary" onClick={reenviar}>Confirmar reenvio</Button>
+                  </div>
+                </>
+              )}
+
+              {reenvioMode === 'sending' && (
+                <div style={{ fontSize: 13, color: 'var(--gray2)', display: 'flex', alignItems: 'center', gap: 4 }}>
+                  Criando nova campanha…
+                </div>
+              )}
+
+              {reenvioMode === 'done' && reenvioResult?.ok && (
+                <div style={{ fontSize: 13, fontWeight: 700, color: '#15803d' }}>
+                  ✓ Nova campanha criada — {reenvioResult.started ?? failedCount} disparo{(reenvioResult.started ?? failedCount) !== 1 ? 's' : ''} iniciado{(reenvioResult.started ?? failedCount) !== 1 ? 's' : ''}.
+                  {' '}
+                  <button onClick={onBack} style={{ background: 'none', border: 'none', color: 'var(--primary-text)', fontWeight: 700, cursor: 'pointer', fontSize: 13, padding: 0 }}>
+                    Ver todos os disparos →
+                  </button>
+                </div>
+              )}
+
+              {reenvioMode === 'done' && !reenvioResult?.ok && (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap' }}>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--red)' }}>
+                    Erro ao reenviar: {reenvioResult?.error ?? 'erro desconhecido'}
+                  </span>
+                  <Button variant="ghost" onClick={() => setReenvioMode('idle')}>Tentar novamente</Button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* ── Recipient table ───────────────────────────────────────────────── */}
           <div className="animate-slide-up delay-3" style={{ background: 'var(--white)', border: '1px solid var(--gray3)', borderRadius: 14, overflow: 'hidden' }}>
             <table style={{ width: '100%', borderCollapse: 'collapse' }}>
               <thead>
                 <tr style={{ background: 'var(--bg)' }}>
                   {['Nome', 'Telefone', 'Status', 'Motivo / Detalhe'].map(h => (
-                    <th key={h} style={{ padding: '9px 16px', textAlign: 'left', fontSize: 10, fontWeight: 800, color: 'var(--gray2)', textTransform: 'uppercase', letterSpacing: '0.07em', borderBottom: '1px solid var(--gray3)', whiteSpace: 'nowrap' }}>
+                    <th key={h} style={{
+                      padding: '9px 16px', textAlign: 'left', fontSize: 10,
+                      fontWeight: 800, color: 'var(--gray2)', textTransform: 'uppercase',
+                      letterSpacing: '0.07em', borderBottom: '1px solid var(--gray3)', whiteSpace: 'nowrap',
+                    }}>
                       {h}
                     </th>
                   ))}
@@ -232,7 +372,11 @@ function DetailView({ campaignId, onBack, onRefresh }: { campaignId: string; onB
               </thead>
               <tbody>
                 {recipients.length === 0 ? (
-                  <tr><td colSpan={4} style={{ padding: '28px 16px', textAlign: 'center', fontSize: 13, color: 'var(--gray2)' }}>Nenhum destinatário</td></tr>
+                  <tr>
+                    <td colSpan={4} style={{ padding: '28px 16px', textAlign: 'center', fontSize: 13, color: 'var(--gray2)' }}>
+                      Nenhum destinatário
+                    </td>
+                  </tr>
                 ) : recipients.map((r, i) => (
                   <tr
                     key={r.id}
@@ -242,9 +386,15 @@ function DetailView({ campaignId, onBack, onRefresh }: { campaignId: string; onB
                       borderBottom: i < recipients.length - 1 ? '1px solid var(--gray3)' : 'none',
                     } as React.CSSProperties}
                   >
-                    <td style={{ padding: '11px 16px', fontSize: 13, fontWeight: 700, color: 'var(--black)' }}>{r.firstName}</td>
-                    <td style={{ padding: '11px 16px', fontFamily: 'monospace', fontSize: 12, color: 'var(--gray)' }}>{fmtPhone(r.phone)}</td>
-                    <td style={{ padding: '11px 16px' }}><StatusBadge status={r.status} /></td>
+                    <td style={{ padding: '11px 16px', fontSize: 13, fontWeight: 700, color: 'var(--black)' }}>
+                      {r.firstName}
+                    </td>
+                    <td style={{ padding: '11px 16px', fontFamily: 'monospace', fontSize: 12, color: 'var(--gray)' }}>
+                      {fmtPhone(r.phone)}
+                    </td>
+                    <td style={{ padding: '11px 16px' }}>
+                      <StatusBadge status={r.status} />
+                    </td>
                     <td style={{ padding: '11px 16px', fontSize: 12, color: r.errorReason ? 'var(--red)' : 'var(--gray2)', fontWeight: r.errorReason ? 600 : 400 }}>
                       {r.errorReason ?? (r.status === 'falhou' ? 'Erro desconhecido' : '—')}
                     </td>
@@ -259,22 +409,60 @@ function DetailView({ campaignId, onBack, onRefresh }: { campaignId: string; onB
   )
 }
 
+// ─── List view ────────────────────────────────────────────────────────────────
+
+function CampaignRow({ c, onClick }: { c: Campaign; onClick: () => void }) {
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        display: 'flex', alignItems: 'center', gap: 16,
+        padding: '14px 16px', cursor: 'pointer',
+        borderBottom: '1px solid var(--gray3)', transition: 'background .12s',
+      }}
+      onMouseEnter={e => (e.currentTarget.style.background = 'var(--bg)')}
+      onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--black)', marginBottom: 3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {c.template}
+        </div>
+        <div style={{ fontSize: 11, color: 'var(--gray2)', fontWeight: 500, display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+          <span>{fmtDate(c.createdAt)}</span>
+          {c.createdByName && <span>por {c.createdByName}</span>}
+          <CampaignStatusBadge status={c.status} />
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', gap: 20, alignItems: 'center', flexShrink: 0 }}>
+        <MetricPill label="Total"    value={c.totalSolicitado} color="var(--ink)"          />
+        <MetricPill label="Enviado"  value={c.enviado}         color="#1d4ed8"              />
+        <MetricPill label="Entregue" value={c.entregue}        color="var(--primary-text)"  />
+        <MetricPill label="Lido"     value={c.lido}            color="var(--green)"         />
+        <MetricPill label="Falhou"   value={c.falhou}          color="var(--red)"           />
+      </div>
+
+      <div style={{ fontSize: 12, color: 'var(--gray2)', flexShrink: 0 }}>›</div>
+    </div>
+  )
+}
+
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function DisparosPage() {
   const [selectedId, setSelectedId] = useState<string | null>(null)
-  const [listKey, setListKey] = useState(0)
+  const [listKey,    setListKey]    = useState(0)
 
   const { data, isLoading, isError, refetch } = useQuery<{ campaigns: Campaign[] }>({
     queryKey: ['blast-campaigns', listKey],
-    queryFn: () => fetch('/api/sdr/blast/campaigns').then(r => r.json()),
+    queryFn:  () => fetch('/api/sdr/blast/campaigns').then(r => r.json()),
     staleTime: 0,
   })
 
   const refresh = useCallback(() => setListKey(k => k + 1), [])
 
   if (selectedId) {
-    return <DetailView campaignId={selectedId} onBack={() => setSelectedId(null)} onRefresh={() => {}} />
+    return <DetailView campaignId={selectedId} onBack={() => setSelectedId(null)} />
   }
 
   const campaigns = data?.campaigns ?? []
@@ -291,14 +479,7 @@ export default function DisparosPage() {
             Histórico de campanhas enviadas e status de entrega.
           </div>
         </div>
-        <button
-          onClick={refresh}
-          style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '8px 16px', borderRadius: 100, border: '1px solid var(--gray3)', background: 'var(--white)', fontSize: 12, fontWeight: 700, color: 'var(--gray)', cursor: 'pointer', transition: 'background .15s' }}
-          onMouseEnter={e => (e.currentTarget.style.background = 'var(--bg)')}
-          onMouseLeave={e => (e.currentTarget.style.background = 'var(--white)')}
-        >
-          <RefreshCw size={13} /> Atualizar
-        </button>
+        <PillBtn onClick={refresh} icon={<RefreshCw size={13} />} label="Atualizar" />
       </div>
 
       {/* List */}


### PR DESCRIPTION
Fase 1a (6/6): add-ons à tela de disparos.

- **Exportar CSV** (visível a todos): RFC-4180, BOM+CRLF p/ Excel, blob client-side, colunas Nome;Telefone;Status;Motivo.
- **Reenviar falhas** (só canDispatch + falhas>0): cria nova campanha com os leadId dos 'falhou' + mesmo template/templateBody + names map; confirmação antes.

tsc limpo. Fecha o histórico de disparos com entrega real + export + reenvio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)