### PR TITLE
feat: instrumenta as 9 ações sensíveis (1d 2/3)

### DIFF
--- a/app/api/sdr/dispatch/route.ts
+++ b/app/api/sdr/dispatch/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
 import { db } from '@/lib/db'
+import { logAudit } from '@/lib/audit'
 import { campaignSettings } from '@/lib/db/schema'
 import { and, eq } from 'drizzle-orm'
 import { assertEntitlement } from '@/lib/entitlements'
@@ -8,7 +9,7 @@ import { requireRole } from '@/lib/auth-guard'
 
 const SOURCE = 'sdr-n8n'
 
-export async function POST() {
+export async function POST(request: Request) {
   const session = await auth()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
@@ -62,6 +63,7 @@ export async function POST() {
       body: JSON.stringify(payload),
       signal: AbortSignal.timeout(15_000),
     })
+    if (res.ok) await logAudit({ req: request, session, action: 'disparo.campanha', metadata: { limiteDiario } })
     return NextResponse.json({ ok: res.ok, status: res.status })
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err)

--- a/app/api/sdr/enroll/route.ts
+++ b/app/api/sdr/enroll/route.ts
@@ -9,6 +9,7 @@
 import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
 import { db } from '@/lib/db'
+import { logAudit } from '@/lib/audit'
 import { campaignSettings } from '@/lib/db/schema'
 import { and, eq } from 'drizzle-orm'
 import { assertEntitlement } from '@/lib/entitlements'
@@ -100,6 +101,7 @@ export async function POST(request: Request) {
       else if (Array.isArray(data.created))       enrolled = data.created.length
     } catch { /* n8n response not JSON or no count field */ }
 
+    if (res.ok) await logAudit({ req: request, session, action: 'enroll', metadata: { leadCount: leadIds.length, fase, agendarPara } })
     return NextResponse.json({ ok: res.ok, status: res.status, enrolled })
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err)

--- a/app/api/sdr/leads/blast/route.ts
+++ b/app/api/sdr/leads/blast/route.ts
@@ -14,6 +14,7 @@
 import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
 import { db } from '@/lib/db'
+import { logAudit } from '@/lib/audit'
 import { dataSources, campaignSettings, blastCampaigns, blastRecipients } from '@/lib/db/schema'
 import { and, eq } from 'drizzle-orm'
 import { decrypt } from '@/lib/crypto'
@@ -229,6 +230,8 @@ export async function POST(request: Request) {
     createdAt: now,
   }))
   await db.insert(blastRecipients).values(recipientRows)
+
+  await logAudit({ req: request, session, action: 'disparo.manual', entityType: 'campaign', entityId: campaignId, metadata: { template, totalSolicitado: leadIds.length, skipped } })
 
   // Build enriched payload for n8n (add campaignId + recipientId per item)
   const enrichedRecipients = recipientRows.map((row, i) => ({

--- a/app/api/sdr/leads/import/route.ts
+++ b/app/api/sdr/leads/import/route.ts
@@ -10,6 +10,7 @@
 
 import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
+import { logAudit } from '@/lib/audit'
 import { db } from '@/lib/db'
 import { dataSources, campaignSettings } from '@/lib/db/schema'
 import { and, eq } from 'drizzle-orm'
@@ -334,6 +335,7 @@ export async function POST(request: Request) {
   }
 
   // ── Report ────────────────────────────────────────────────────────────────────
+  await logAudit({ req: request, session, action: 'leads.import', metadata: { inserted: novos.length, updated: updates.length, skipped: ignorados.length, total: rawRows.length } })
   return NextResponse.json({
     ok: true,
     totalLinhas: rawRows.length,

--- a/app/api/sdr/settings/route.ts
+++ b/app/api/sdr/settings/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
 import { db } from '@/lib/db'
+import { logAudit } from '@/lib/audit'
 import { campaignSettings } from '@/lib/db/schema'
 import { and, eq } from 'drizzle-orm'
 import { assertEntitlement } from '@/lib/entitlements'
@@ -133,6 +134,7 @@ export async function PUT(request: Request) {
   const rawSettings = (typeof body.settings === 'object' && body.settings !== null
     ? body.settings
     : {}) as Record<string, unknown>
+  const payloadKeys = Object.keys(rawSettings)
 
   // Validate webhook URL if provided (empty string = not configured, skip)
   if (rawSettings.n8nWebhookUrl !== undefined && rawSettings.n8nWebhookUrl !== '') {
@@ -260,6 +262,8 @@ export async function PUT(request: Request) {
       updatedAt: now,
     })
   }
+
+  await logAudit({ req: request, session, action: 'settings.update', metadata: { changedKeys: payloadKeys, status } })
 
   // Deliver to n8n webhook if a valid URL is configured
   const webhookUrl =

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/auth'
 import { db } from '@/lib/db'
+import { logAudit } from '@/lib/audit'
 import { tenants, users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 
@@ -43,5 +44,7 @@ export async function PUT(req: NextRequest) {
     })
     .where(eq(tenants.id, session.user.tenantId))
 
+  const changedKeys = Object.entries({ primaryColor, logoUrl, name }).filter(([, v]) => v !== undefined).map(([k]) => k)
+  await logAudit({ req, session, action: 'whitelabel.update', metadata: { changedKeys } })
   return NextResponse.json({ ok: true })
 }

--- a/app/api/users/[userId]/route.ts
+++ b/app/api/users/[userId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/auth'
 import { db } from '@/lib/db'
+import { logAudit } from '@/lib/audit'
 import { users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import type { Session } from 'next-auth'
@@ -82,10 +83,14 @@ export async function PUT(req: NextRequest, { params }: Params) {
     .where(eq(users.id, userId))
     .then(r => r[0])
 
+  const changes: Record<string, unknown> = {}
+  if (updates.name !== undefined) changes.name = updates.name
+  if (updates.role !== undefined) changes.role = updates.role
+  await logAudit({ req, session, action: 'user.update', entityType: 'user', entityId: userId, metadata: { changes }, tenantId: target.tenantId ?? undefined })
   return NextResponse.json(updated)
 }
 
-export async function DELETE(_req: NextRequest, { params }: Params) {
+export async function DELETE(req: NextRequest, { params }: Params) {
   const session = await auth()
   if (!session || !canManage(session.user.role)) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
@@ -102,5 +107,6 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
 
   await db.delete(users).where(eq(users.id, userId))
 
+  await logAudit({ req, session, action: 'user.delete', entityType: 'user', entityId: userId, tenantId: target.tenantId ?? undefined })
   return NextResponse.json({ message: 'Usuário removido com sucesso.' })
 }

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/auth'
 import { db } from '@/lib/db'
+import { logAudit } from '@/lib/audit'
 import { users, passwordResetTokens } from '@/lib/db/schema'
 import { eq, and, isNull } from 'drizzle-orm'
 import bcrypt from 'bcryptjs'
@@ -112,6 +113,7 @@ export async function POST(req: NextRequest) {
 
   await sendInviteEmail({ to: email, userName: name, brandName, inviteLink })
 
+  await logAudit({ req, session, action: 'user.create', entityType: 'user', entityId: id, metadata: { email: email.toLowerCase().trim(), role }, tenantId })
   return NextResponse.json({ id, name: name.trim(), email: email.toLowerCase().trim(), role, createdAt: now }, { status: 201 })
 }
 


### PR DESCRIPTION
1d (2/3): cada ação sensível grava em audit_logs.

| Rota | action | metadata |
|---|---|---|
| blast | disparo.manual | template, total, skipped |
| dispatch | disparo.campanha | limiteDiario |
| enroll | enroll | leadCount, fase, agendarPara |
| sdr/settings | settings.update | **changedKeys (só nomes)**, status |
| import | leads.import | inserted, updated, skipped, total |
| users POST/PUT/DELETE | user.create/update/delete | email/role, changes (sem senha) |
| settings | whitelabel.update | changedKeys |

**Nunca loga segredos** (só nomes de chave). Chamadas no ponto de sucesso; erro de validação não loga. tsc limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)