### PR TITLE
feat: auditoria master cross-tenant

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -7,6 +7,7 @@ import { useWhiteLabel } from '@/stores/whiteLabelStore'
 import { useUser } from '@/stores/userStore'
 import { initials } from '@/lib/utils'
 import { Pencil, Trash2, Clock, Search, Check, Database, KeyRound } from 'lucide-react'
+import { ACTION_LABELS, fmtDateTime, fmtDetail } from '@/lib/audit-format'
 import { SparkleIcon } from '@/components/icons/SparkleIcon'
 import { useModules } from '@/components/ModulesProvider'
 
@@ -1062,18 +1063,6 @@ function UsersSection({ meId, search, inviteOpen, onInviteOpenChange }: { meId: 
 
 // ─── AuditSection ─────────────────────────────────────────────────────────────
 
-const ACTION_LABELS: Record<string, string> = {
-  'disparo.manual':    'Disparo manual',
-  'disparo.campanha':  'Disparo (campanha)',
-  'enroll':            'Adição à campanha',
-  'settings.update':   'Alterou configurações',
-  'leads.import':      'Importou leads',
-  'user.create':       'Criou usuário',
-  'user.update':       'Editou usuário',
-  'user.delete':       'Removeu usuário',
-  'whitelabel.update': 'Alterou marca',
-}
-
 type AuditLog = {
   id: string
   createdAt: string
@@ -1085,56 +1074,6 @@ type AuditLog = {
   entityId: string | null
   metadata: Record<string, unknown>
   ip: string | null
-}
-
-function fmtDateTime(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString('pt-BR', { day: '2-digit', month: '2-digit', year: '2-digit', hour: '2-digit', minute: '2-digit' })
-  } catch { return '—' }
-}
-
-function fmtDetail(action: string, entityType: string | null, entityId: string | null, meta: Record<string, unknown>): string {
-  const parts: string[] = []
-  if (entityId) parts.push(`#${String(entityId).slice(0, 8)}`)
-  switch (action) {
-    case 'disparo.manual':
-      if (meta.template) parts.push(`tmpl: ${meta.template}`)
-      if (meta.totalSolicitado !== undefined) parts.push(`${meta.totalSolicitado} leads`)
-      if (meta.skipped) parts.push(`${meta.skipped} pulados`)
-      break
-    case 'disparo.campanha':
-      parts.push(`limite: ${meta.limiteDiario ?? '—'}`)
-      break
-    case 'enroll':
-      if (meta.leadCount !== undefined) parts.push(`${meta.leadCount} leads`)
-      if (meta.fase) parts.push(String(meta.fase))
-      break
-    case 'settings.update':
-      if (Array.isArray(meta.changedKeys) && meta.changedKeys.length) parts.push(meta.changedKeys.join(', '))
-      if (meta.status) parts.push(String(meta.status))
-      break
-    case 'leads.import':
-      if (meta.inserted !== undefined) parts.push(`${meta.inserted} novos`)
-      if (meta.updated !== undefined) parts.push(`${meta.updated} atualizados`)
-      if (meta.skipped !== undefined) parts.push(`${meta.skipped} pulados`)
-      break
-    case 'user.create':
-      if (meta.email) parts.push(String(meta.email))
-      if (meta.role) parts.push(String(meta.role))
-      break
-    case 'user.update': {
-      const ch = meta.changes as Record<string, unknown> | undefined
-      if (ch && typeof ch === 'object') {
-        const pairs = Object.entries(ch).map(([k, v]) => `${k}: ${v}`).join(', ')
-        if (pairs) parts.push(pairs)
-      }
-      break
-    }
-    case 'whitelabel.update':
-      if (Array.isArray(meta.changedKeys) && meta.changedKeys.length) parts.push(meta.changedKeys.join(', '))
-      break
-  }
-  return parts.join(' · ') || '—'
 }
 
 const LIMIT = 50

--- a/app/(master)/MasterShell.tsx
+++ b/app/(master)/MasterShell.tsx
@@ -2,9 +2,10 @@
 import { usePathname } from 'next/navigation'
 
 const NAV = [
-  { href: '/master', label: 'Dashboard' },
-  { href: '/master/tenants', label: 'Tenants' },
-  { href: '/master/plans', label: 'Planos' },
+  { href: '/master',           label: 'Dashboard' },
+  { href: '/master/tenants',   label: 'Tenants' },
+  { href: '/master/plans',     label: 'Planos' },
+  { href: '/master/auditoria', label: 'Auditoria' },
 ]
 
 type Props = {

--- a/app/(master)/master/auditoria/AuditExplorer.tsx
+++ b/app/(master)/master/auditoria/AuditExplorer.tsx
@@ -1,0 +1,234 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { ACTION_LABELS, fmtDateTime, fmtDetail } from '@/lib/audit-format'
+
+type TenantItem = { id: string; name: string }
+
+type AuditLog = {
+  id: string
+  createdAt: string
+  actorName: string | null
+  actorEmail: string | null
+  actorRole: string | null
+  action: string
+  entityType: string | null
+  entityId: string | null
+  metadata: Record<string, unknown>
+  ip: string | null
+  tenantId: string | null
+  tenantName: string | null
+}
+
+const LIMIT = 50
+
+// ── styles ────────────────────────────────────────────────────────────────────
+
+const TH: React.CSSProperties = {
+  padding: '10px 16px',
+  textAlign: 'left',
+  fontSize: 11,
+  fontWeight: 700,
+  color: '#888',
+  letterSpacing: '0.06em',
+  borderBottom: '1px solid #e3e4de',
+  whiteSpace: 'nowrap',
+  background: '#f8f8f6',
+}
+
+const TD: React.CSSProperties = {
+  padding: '11px 16px',
+  fontSize: 12,
+  color: '#555',
+  verticalAlign: 'top',
+  borderBottom: '1px solid #f0f0ee',
+}
+
+const selectStyle: React.CSSProperties = {
+  padding: '7px 12px',
+  fontFamily: 'Manrope, sans-serif',
+  fontSize: 12,
+  fontWeight: 600,
+  color: '#121316',
+  background: '#fff',
+  border: '1px solid #e3e4de',
+  borderRadius: 8,
+  outline: 'none',
+  cursor: 'pointer',
+  minWidth: 160,
+}
+
+// ── component ─────────────────────────────────────────────────────────────────
+
+export function AuditExplorer({ tenants }: { tenants: TenantItem[] }) {
+  const [tenantFilter, setTenantFilter] = useState('')
+  const [actionFilter, setActionFilter] = useState('')
+  const [logs, setLogs]     = useState<AuditLog[]>([])
+  const [total, setTotal]   = useState(0)
+  const [offset, setOffset] = useState(0)
+  const [loading, setLoading]         = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [error, setError]   = useState('')
+
+  async function load(newOffset: number, tFilter: string, aFilter: string, append: boolean) {
+    if (newOffset === 0) setLoading(true); else setLoadingMore(true)
+    setError('')
+    try {
+      const qs = new URLSearchParams({
+        scope: 'all',
+        limit: String(LIMIT),
+        offset: String(newOffset),
+        ...(tFilter ? { tenantId: tFilter } : {}),
+        ...(aFilter ? { action: aFilter } : {}),
+      })
+      const res = await fetch(`/api/audit-logs?${qs}`)
+      if (!res.ok) { setError('Erro ao carregar logs.'); return }
+      const data = await res.json() as { logs: AuditLog[]; total: number }
+      setLogs(prev => append ? [...prev, ...data.logs] : data.logs)
+      setTotal(data.total)
+      setOffset(newOffset)
+    } catch { setError('Erro ao carregar logs.') }
+    finally { setLoading(false); setLoadingMore(false) }
+  }
+
+  useEffect(() => {
+    load(0, tenantFilter, actionFilter, false)
+  }, [tenantFilter, actionFilter])
+
+  const hasMore = logs.length < total
+
+  return (
+    <div>
+      {/* Filter bar */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16, flexWrap: 'wrap' }}>
+        <select
+          value={tenantFilter}
+          onChange={e => { setTenantFilter(e.target.value); setOffset(0) }}
+          style={selectStyle}
+        >
+          <option value="">Todos os tenants</option>
+          {tenants.map(t => (
+            <option key={t.id} value={t.id}>{t.name}</option>
+          ))}
+        </select>
+
+        <select
+          value={actionFilter}
+          onChange={e => { setActionFilter(e.target.value); setOffset(0) }}
+          style={selectStyle}
+        >
+          <option value="">Todas as ações</option>
+          {Object.entries(ACTION_LABELS).map(([v, l]) => (
+            <option key={v} value={v}>{l}</option>
+          ))}
+        </select>
+
+        {total > 0 && !loading && (
+          <span style={{ fontSize: 12, color: '#888', fontWeight: 500 }}>
+            {total} registro{total !== 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+
+      {/* Table card */}
+      <div style={{ background: '#fff', border: '1px solid #e3e4de', borderRadius: 12, overflow: 'hidden' }}>
+
+        {/* Skeleton */}
+        {loading && (
+          <div style={{ padding: '24px 20px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {[1, 2, 3, 4, 5].map(i => (
+              <div key={i} style={{ height: 34, borderRadius: 6, background: '#f0f0ee', animation: 'pulse 1.4s ease-in-out infinite' }} />
+            ))}
+          </div>
+        )}
+
+        {/* Error */}
+        {!loading && error && (
+          <div style={{ padding: '24px 20px', fontSize: 13, color: '#d93025', fontWeight: 600 }}>{error}</div>
+        )}
+
+        {/* Empty */}
+        {!loading && !error && logs.length === 0 && (
+          <div style={{ padding: '40px 20px', textAlign: 'center', fontSize: 13, color: '#aaa' }}>
+            Nenhum registro de auditoria encontrado.
+          </div>
+        )}
+
+        {/* Table */}
+        {!loading && !error && logs.length > 0 && (
+          <div style={{ overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 820 }}>
+              <thead>
+                <tr>
+                  <th style={TH}>Tenant</th>
+                  <th style={TH}>Quando</th>
+                  <th style={TH}>Quem</th>
+                  <th style={TH}>Ação</th>
+                  <th style={TH}>Detalhe</th>
+                  <th style={TH}>IP</th>
+                </tr>
+              </thead>
+              <tbody>
+                {logs.map(log => (
+                  <tr key={log.id}>
+                    <td style={{ ...TD, fontWeight: 700, color: '#121316', whiteSpace: 'nowrap' }}>
+                      {log.tenantName ?? log.tenantId ?? '—'}
+                    </td>
+                    <td style={{ ...TD, whiteSpace: 'nowrap', color: '#121316' }}>
+                      {fmtDateTime(log.createdAt)}
+                    </td>
+                    <td style={{ ...TD, minWidth: 140 }}>
+                      <div style={{ fontWeight: 700, color: '#121316', fontSize: 12 }}>{log.actorName ?? '—'}</div>
+                      <div style={{ color: '#999', fontSize: 11 }}>{log.actorEmail ?? ''}</div>
+                    </td>
+                    <td style={{ ...TD, whiteSpace: 'nowrap' }}>
+                      <span style={{
+                        display: 'inline-block',
+                        padding: '2px 8px',
+                        borderRadius: 4,
+                        fontSize: 11,
+                        fontWeight: 700,
+                        background: 'rgba(255,180,0,0.1)',
+                        color: '#7A5600',
+                      }}>
+                        {ACTION_LABELS[log.action] ?? log.action}
+                      </span>
+                    </td>
+                    <td style={{ ...TD, maxWidth: 300, wordBreak: 'break-word' }}>
+                      {fmtDetail(log.action, log.entityType, log.entityId, log.metadata)}
+                    </td>
+                    <td style={{ ...TD, fontFamily: 'monospace', fontSize: 11, whiteSpace: 'nowrap' }}>
+                      {log.ip ?? '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Load more */}
+        {!loading && !error && hasMore && (
+          <div style={{ padding: '14px 20px', borderTop: '1px solid #f0f0ee', textAlign: 'center' }}>
+            <button
+              onClick={() => load(offset + LIMIT, tenantFilter, actionFilter, true)}
+              disabled={loadingMore}
+              style={{
+                padding: '7px 20px',
+                fontFamily: 'Manrope, sans-serif',
+                fontSize: 13,
+                fontWeight: 700,
+                background: loadingMore ? '#f0f0ee' : '#fff',
+                color: loadingMore ? '#aaa' : '#121316',
+                border: '1px solid #e3e4de',
+                borderRadius: 100,
+                cursor: loadingMore ? 'not-allowed' : 'pointer',
+              }}
+            >
+              {loadingMore ? 'Carregando…' : `Carregar mais (${total - logs.length} restantes)`}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/(master)/master/auditoria/page.tsx
+++ b/app/(master)/master/auditoria/page.tsx
@@ -1,0 +1,23 @@
+import { db } from '@/lib/db'
+import { tenants } from '@/lib/db/schema'
+import { asc } from 'drizzle-orm'
+import { AuditExplorer } from './AuditExplorer'
+
+export default async function AuditoriaPage() {
+  const tenantList = await db
+    .select({ id: tenants.id, name: tenants.name })
+    .from(tenants)
+    .orderBy(asc(tenants.name))
+
+  return (
+    <div style={{ padding: '40px 48px', maxWidth: 1200 }}>
+      <div style={{ marginBottom: 28 }}>
+        <h1 style={{ fontSize: 22, fontWeight: 800, color: '#121316', letterSpacing: '-0.02em', marginBottom: 4 }}>
+          Auditoria
+        </h1>
+        <p style={{ fontSize: 13, color: '#666' }}>Ações de todos os tenants, mais recentes primeiro.</p>
+      </div>
+      <AuditExplorer tenants={tenantList} />
+    </div>
+  )
+}

--- a/app/api/audit-logs/route.ts
+++ b/app/api/audit-logs/route.ts
@@ -1,13 +1,15 @@
 // GET /api/audit-logs
 //
-// Returns paginated audit log for the session's tenant.
+// Returns paginated audit log.
 // Auth: admin or master only.
 // Query params: ?limit (default 50, max 200) | ?offset | ?action
+//   Master-only extras: ?scope=all (cross-tenant) | ?tenantId=<id> (filter to tenant)
+// Admin always scoped to own tenantId; scope/tenantId params are ignored for admin.
 
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/auth'
 import { db } from '@/lib/db'
-import { auditLogs } from '@/lib/db/schema'
+import { auditLogs, tenants } from '@/lib/db/schema'
 import { and, eq, sql, desc } from 'drizzle-orm'
 import { requireRole } from '@/lib/auth-guard'
 
@@ -17,18 +19,73 @@ export async function GET(req: NextRequest) {
   const roleCheck = requireRole(['admin', 'master'], session)
   if (roleCheck) return roleCheck
 
-  const { tenantId } = session.user
   const sp = req.nextUrl.searchParams
 
   const limit  = Math.min(Math.max(parseInt(sp.get('limit')  ?? '50',  10) || 50,  1), 200)
   const offset = Math.max(parseInt(sp.get('offset') ?? '0',   10) || 0,  0)
   const action = sp.get('action') ?? ''
 
+  const isMaster      = session.user.role === 'master'
+  const scopeAll      = isMaster && sp.get('scope') === 'all'
+  const tenantIdParam = sp.get('tenantId') ?? ''
+
+  // Resolve the tenant filter:
+  //  - non-master: always own tenantId (ignore all params)
+  //  - master + scope=all + no tenantId param: no tenant filter (all tenants)
+  //  - master + scope=all + tenantId param: filter to that tenant
+  //  - master without scope=all: treat as own tenant (backward compat)
+  const tenantIdFilter: string | null =
+    !isMaster        ? session.user.tenantId
+    : scopeAll && tenantIdParam ? tenantIdParam
+    : scopeAll       ? null
+    : session.user.tenantId
+
   const where = and(
-    eq(auditLogs.tenantId, tenantId),
+    tenantIdFilter !== null ? eq(auditLogs.tenantId, tenantIdFilter) : undefined,
     action ? eq(auditLogs.action, action) : undefined,
   )
 
+  if (scopeAll) {
+    // Cross-tenant query: JOIN with tenants to get tenant name
+    const [rows, countRow] = await Promise.all([
+      db
+        .select({
+          id:          auditLogs.id,
+          createdAt:   auditLogs.createdAt,
+          actorName:   auditLogs.actorName,
+          actorEmail:  auditLogs.actorEmail,
+          actorRole:   auditLogs.actorRole,
+          action:      auditLogs.action,
+          entityType:  auditLogs.entityType,
+          entityId:    auditLogs.entityId,
+          metadata:    auditLogs.metadata,
+          ip:          auditLogs.ip,
+          tenantId:    auditLogs.tenantId,
+          tenantName:  tenants.name,
+        })
+        .from(auditLogs)
+        .leftJoin(tenants, eq(auditLogs.tenantId, tenants.id))
+        .where(where)
+        .orderBy(desc(auditLogs.createdAt))
+        .limit(limit)
+        .offset(offset),
+      db
+        .select({ total: sql<number>`count(*)` })
+        .from(auditLogs)
+        .where(where),
+    ])
+
+    return NextResponse.json({
+      logs: rows.map(r => ({
+        ...r,
+        metadata: (() => { try { return JSON.parse(r.metadata) } catch { return {} } })(),
+        createdAt: r.createdAt instanceof Date ? r.createdAt.toISOString() : r.createdAt,
+      })),
+      total: Number(countRow[0]?.total ?? 0),
+    })
+  }
+
+  // Default (scoped) query — same as before, no tenant join
   const [rows, countRow] = await Promise.all([
     db
       .select({

--- a/lib/audit-format.ts
+++ b/lib/audit-format.ts
@@ -1,0 +1,61 @@
+export const ACTION_LABELS: Record<string, string> = {
+  'disparo.manual':    'Disparo manual',
+  'disparo.campanha':  'Disparo (campanha)',
+  'enroll':            'Adição à campanha',
+  'settings.update':   'Alterou configurações',
+  'leads.import':      'Importou leads',
+  'user.create':       'Criou usuário',
+  'user.update':       'Editou usuário',
+  'user.delete':       'Removeu usuário',
+  'whitelabel.update': 'Alterou marca',
+}
+
+export function fmtDateTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString('pt-BR', { day: '2-digit', month: '2-digit', year: '2-digit', hour: '2-digit', minute: '2-digit' })
+  } catch { return '—' }
+}
+
+export function fmtDetail(action: string, entityType: string | null, entityId: string | null, meta: Record<string, unknown>): string {
+  const parts: string[] = []
+  if (entityId) parts.push(`#${String(entityId).slice(0, 8)}`)
+  switch (action) {
+    case 'disparo.manual':
+      if (meta.template) parts.push(`tmpl: ${meta.template}`)
+      if (meta.totalSolicitado !== undefined) parts.push(`${meta.totalSolicitado} leads`)
+      if (meta.skipped) parts.push(`${meta.skipped} pulados`)
+      break
+    case 'disparo.campanha':
+      parts.push(`limite: ${meta.limiteDiario ?? '—'}`)
+      break
+    case 'enroll':
+      if (meta.leadCount !== undefined) parts.push(`${meta.leadCount} leads`)
+      if (meta.fase) parts.push(String(meta.fase))
+      break
+    case 'settings.update':
+      if (Array.isArray(meta.changedKeys) && meta.changedKeys.length) parts.push(meta.changedKeys.join(', '))
+      if (meta.status) parts.push(String(meta.status))
+      break
+    case 'leads.import':
+      if (meta.inserted !== undefined) parts.push(`${meta.inserted} novos`)
+      if (meta.updated !== undefined) parts.push(`${meta.updated} atualizados`)
+      if (meta.skipped !== undefined) parts.push(`${meta.skipped} pulados`)
+      break
+    case 'user.create':
+      if (meta.email) parts.push(String(meta.email))
+      if (meta.role) parts.push(String(meta.role))
+      break
+    case 'user.update': {
+      const ch = meta.changes as Record<string, unknown> | undefined
+      if (ch && typeof ch === 'object') {
+        const pairs = Object.entries(ch).map(([k, v]) => `${k}: ${v}`).join(', ')
+        if (pairs) parts.push(pairs)
+      }
+      break
+    }
+    case 'whitelabel.update':
+      if (Array.isArray(meta.changedKeys) && meta.changedKeys.length) parts.push(meta.changedKeys.join(', '))
+      break
+  }
+  return parts.join(' · ') || '—'
+}


### PR DESCRIPTION
Fecha o backlog de auditoria: visão de operador da plataforma.

- `GET /api/audit-logs?scope=all` (**só master**): cross-tenant com `tenantName` (JOIN), + `?tenantId` filtra um tenant. **Invariante de segurança**: não-master sempre travado no próprio tenantId (params ignorados); default sem scope = comportamento de hoje.
- `lib/audit-format.ts`: ACTION_LABELS/fmtDateTime/fmtDetail compartilhados (removida a duplicação no settings).
- Página `/master/auditoria` (Server + AuditExplorer client, tema claro do master): filtros Tenant+Ação, coluna Tenant, paginação. Item na nav do MasterShell.

tsc limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)