### PR TITLE
feat: reorganiza navegação por domínio (R1)

### DIFF
--- a/app/(app)/sdr-ia/layout.tsx
+++ b/app/(app)/sdr-ia/layout.tsx
@@ -3,17 +3,37 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useModules } from '@/components/ModulesProvider'
 
-const TABS = [
-  { href: '/sdr-ia/parametros', label: 'Parâmetros', moduleKey: 'sdr.parametros'              },
-  { href: '/sdr-ia/leads',      label: 'Leads',      moduleKey: 'sdr.parametros'              },
-  { href: '/sdr-ia/contatos',   label: 'Contatos',   moduleKey: 'integration.ycloud-whatsapp' },
-  { href: '/sdr-ia/conversas',  label: 'Conversas',  moduleKey: 'integration.ycloud-whatsapp' },
+type Tab = { href: string; label: string; isVisible: (mods: string[]) => boolean }
+
+// Sub-nav shown when in the Conversas context (/sdr-ia/conversas or /sdr-ia/contatos)
+const CONV_TABS: Tab[] = [
+  { href: '/sdr-ia/conversas', label: 'Conversas', isVisible: m => m.includes('integration.ycloud-whatsapp') },
+  { href: '/sdr-ia/contatos',  label: 'Contatos',  isVisible: m => m.includes('integration.ycloud-whatsapp') },
 ]
+
+// Sub-nav shown when in the Disparos context (/sdr-ia/disparos or /sdr-ia/leads)
+const DISPAR_TABS: Tab[] = [
+  { href: '/sdr-ia/leads',    label: 'Leads',     isVisible: m => m.includes('sdr.parametros') },
+  { href: '/sdr-ia/disparos', label: 'Histórico', isVisible: m => m.includes('sdr.dashboard') || m.includes('sdr.parametros') },
+]
+
+function inConvContext(p: string) {
+  return p.startsWith('/sdr-ia/conversas') || p.startsWith('/sdr-ia/contatos')
+}
+
+function inDisparContext(p: string) {
+  return p.startsWith('/sdr-ia/disparos') || p.startsWith('/sdr-ia/leads')
+}
 
 export default function SdrIaLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   const modules  = useModules()
-  const visibleTabs = TABS.filter(t => modules.includes(t.moduleKey))
+
+  const contextTabs = inConvContext(pathname) ? CONV_TABS
+    : inDisparContext(pathname) ? DISPAR_TABS
+    : []
+
+  const visibleTabs = contextTabs.filter(t => t.isVisible(modules))
 
   return (
     <div>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 'use client'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { LayoutGrid, BarChart3, Sparkles, Settings, Radio } from 'lucide-react'
+import { LayoutGrid, BarChart3, MessageSquare, Settings, Send } from 'lucide-react'
 import { useSidebar } from '@/stores/sidebarStore'
 import { useModules } from '@/components/ModulesProvider'
 import { useIsMobile } from '@/lib/hooks/useMediaQuery'
@@ -26,22 +26,23 @@ const navItems: NavGroup[] = [
     section: 'Principal',
     items: [
       {
-        href: '/dashboard', label: 'Dashboard',
+        href: '/dashboard', label: 'Visão geral',
         icon: <LayoutGrid size={16} />,
+        isActive: (p) => p.startsWith('/dashboard'),
+      },
+      {
+        href: '/sdr-ia/conversas', label: 'Conversas',
+        icon: <MessageSquare size={16} />,
+        isActive: (p) => p.startsWith('/sdr-ia/conversas') || p.startsWith('/sdr-ia/contatos'),
+      },
+      {
+        href: '/sdr-ia/disparos', label: 'Disparos',
+        icon: <Send size={16} />,
+        isActive: (p) => p.startsWith('/sdr-ia/disparos') || p.startsWith('/sdr-ia/leads'),
       },
       {
         href: '/pipeline', label: 'Pipeline',
         icon: <BarChart3 size={16} />,
-      },
-      {
-        href: '/sdr-ia/parametros', label: 'SDR IA',
-        icon: <Sparkles size={16} />,
-        isActive: (p) => p.startsWith('/sdr-ia') && !p.startsWith('/sdr-ia/disparos'),
-      },
-      {
-        href: '/sdr-ia/disparos', label: 'Disparos',
-        icon: <Radio size={16} />,
-        isActive: (p) => p.startsWith('/sdr-ia/disparos'),
       },
     ],
   },
@@ -66,10 +67,10 @@ export function Sidebar() {
   const overlay = !pinned || isMobile
 
   function isItemVisible(href: string): boolean {
-    if (href === '/settings')      return true
-    if (href === '/dashboard')     return modules.some(k => k.startsWith('dashboard.'))
-    if (href === '/pipeline')      return modules.includes('pipeline')
-    if (href === '/sdr-ia/parametros') return modules.includes('sdr.dashboard') || modules.includes('sdr.parametros')
+    if (href === '/settings')          return true
+    if (href === '/dashboard')         return modules.some(k => k.startsWith('dashboard.'))
+    if (href === '/pipeline')          return modules.includes('pipeline')
+    if (href === '/sdr-ia/conversas')  return modules.includes('integration.ycloud-whatsapp')
     if (href === '/sdr-ia/disparos')   return modules.includes('sdr.dashboard') || modules.includes('sdr.parametros')
     return true
   }

--- a/lib/modules.ts
+++ b/lib/modules.ts
@@ -62,7 +62,7 @@ export function firstAllowedPath(modules: string[]): string {
   const dashTabs = ['dashboard.overview', 'dashboard.ranking', 'dashboard.marketing']
   const firstDash = MODULES.find(m => dashTabs.includes(m.key) && modules.includes(m.key))
   if (firstDash) return firstDash.path
-  if (modules.includes('sdr.dashboard')) return '/sdr-ia/dashboard'
+  if (modules.includes('sdr.dashboard') || modules.includes('sdr.parametros')) return '/sdr-ia/disparos'
   if (modules.includes('pipeline')) return '/pipeline'
   return '/settings'
 }


### PR DESCRIPTION
Reorg de IA (1/2): agrupa por domínio.

- Sidebar: **Visão geral · Conversas · Disparos · Pipeline · Configurações** (remove 'SDR IA'); gating por módulo preservado (`isItemVisible` por href).
- Sub-nav do /sdr-ia agora **contextual**: Conversas/Contatos no contexto Conversas; Leads/Histórico no contexto Disparos; nada em Parâmetros.
- `firstAllowedPath` do SDR → `/sdr-ia/disparos` (rota válida; antes apontava p/ a órfã /sdr-ia/dashboard).

Rotas inalteradas. tsc limpo. (R2 trata Parâmetros→Configurações + remove a órfã + atualiza lib/modules.ts.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)