### PR TITLE
feat: Parâmetros→Configurações + limpeza (R2)

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -367,7 +367,7 @@ export default function DashboardPage() {
       <div className="animate-slide-up delay-1" style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: 24, gap: 16 }}>
         <div>
           <div style={{ fontSize: 22, fontWeight: 800, color: 'var(--black)', letterSpacing: '-0.02em', marginBottom: 4 }}>
-            SDR IA
+            Visão geral
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
             <div style={{ fontSize: 13, color: 'var(--gray)' }}>

--- a/app/(app)/sdr-ia/dashboard/page.tsx
+++ b/app/(app)/sdr-ia/dashboard/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation'
-
-export default function SdrIaDashboardPage() {
-  redirect('/dashboard')
-}

--- a/app/(app)/sdr-ia/parametros/page.tsx
+++ b/app/(app)/sdr-ia/parametros/page.tsx
@@ -337,6 +337,16 @@ export default function ParametrosPage() {
   return (
     <div>
 
+      {/* ── Breadcrumb ───────────────────────────────────────────── */}
+      <div style={{ marginBottom: 16 }}>
+        <Link
+          href="/settings?tab=campanha-sdr"
+          style={{ fontSize: 12, fontWeight: 600, color: 'var(--gray)', textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 4 }}
+        >
+          ← Voltar para Configurações
+        </Link>
+      </div>
+
       {/* ── Banner — sempre visível ──────────────────────────────── */}
       <div style={{
         display: 'flex', alignItems: 'flex-start', gap: 12,

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -16,14 +16,15 @@ const PRESET_COLORS = [
   '#7C3AED', '#DB2777', '#0891B2', '#059669',
 ]
 
-type TabKey = 'perfil' | 'marca' | 'integracoes' | 'equipe' | 'auditoria'
+type TabKey = 'perfil' | 'marca' | 'integracoes' | 'equipe' | 'auditoria' | 'campanha-sdr'
 type IntegStatus = 'loading' | 'connected' | 'disconnected' | 'error' | 'pending'
-const TABS: { id: TabKey; label: string; adminOnly?: boolean }[] = [
-  { id: 'integracoes', label: 'Integrações' },
-  { id: 'equipe',      label: 'Equipe' },
-  { id: 'perfil',      label: 'Perfil' },
-  { id: 'marca',       label: 'Marca',      adminOnly: true },
-  { id: 'auditoria',   label: 'Auditoria',  adminOnly: true },
+const TABS: { id: TabKey; label: string; adminOnly?: boolean; moduleGate?: string }[] = [
+  { id: 'integracoes',  label: 'Integrações' },
+  { id: 'campanha-sdr', label: 'Campanha SDR', moduleGate: 'sdr.parametros' },
+  { id: 'equipe',       label: 'Equipe' },
+  { id: 'perfil',       label: 'Perfil' },
+  { id: 'marca',        label: 'Marca',     adminOnly: true },
+  { id: 'auditoria',    label: 'Auditoria', adminOnly: true },
 ]
 
 // ─── Integration icons ────────────────────────────────────────────────────────
@@ -321,7 +322,10 @@ export default function SettingsPage() {
   const users = data?.users ?? []
   const me = meData?.user
   const isAdmin = me?.role === 'admin' || me?.role === 'master'
-  const visibleTabs = TABS.filter(t => !t.adminOnly || isAdmin)
+  const visibleTabs = TABS.filter(t =>
+    (!t.adminOnly || isAdmin) &&
+    (!t.moduleGate || modules.includes(t.moduleGate))
+  )
   const equipeQ = equipeSearch.trim().toLowerCase()
   const filteredEquipeUsers: any[] = equipeQ
     ? users.filter((u: any) => u.name?.toLowerCase().includes(equipeQ) || u.email?.toLowerCase().includes(equipeQ))
@@ -641,6 +645,28 @@ export default function SettingsPage() {
       )}
 
       {/* ── Auditoria ──────────────────────────────────────────────────────── */}
+      {tab === 'campanha-sdr' && (
+        <div className="animate-slide-up delay-2">
+          <div style={{ background: 'var(--white)', border: '1px solid var(--gray3)', borderRadius: 16, padding: 28, boxShadow: 'var(--shadow)', maxWidth: 520 }}>
+            <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--black)', marginBottom: 8 }}>Campanha SDR</div>
+            <div style={{ fontSize: 13, color: 'var(--gray)', lineHeight: 1.6, marginBottom: 20 }}>
+              Configure o agente de prospecção: tom, objetivo, horários, templates e limites de disparo.
+            </div>
+            <Link
+              href="/sdr-ia/parametros"
+              style={{
+                display: 'inline-flex', alignItems: 'center', gap: 8,
+                padding: '10px 22px', borderRadius: 100,
+                background: 'var(--primary)', color: '#fff',
+                fontSize: 13, fontWeight: 700, textDecoration: 'none',
+              }}
+            >
+              Abrir configuração da campanha
+            </Link>
+          </div>
+        </div>
+      )}
+
       {tab === 'auditoria' && isAdmin && (
         <div className="animate-slide-up delay-2">
           <AuditSection />

--- a/lib/modules.ts
+++ b/lib/modules.ts
@@ -9,7 +9,7 @@ export interface ModuleDef {
 
 export const MODULES: ModuleDef[] = [
   { key: 'pipeline',               label: 'Pipeline',          type: 'sidebar',       path: '/pipeline' },
-  { key: 'sdr.dashboard',          label: 'SDR IA',            type: 'sidebar',       path: '/sdr-ia/dashboard' },
+  { key: 'sdr.dashboard',          label: 'SDR / Disparos',    type: 'sidebar',       path: '/sdr-ia/disparos' },
   { key: 'sdr.parametros',         label: 'Parâmetros SDR',    type: 'sidebar',       path: '/sdr-ia/parametros' },
   { key: 'dashboard.overview',     label: 'Visão Geral',       type: 'dashboard-tab', path: '/dashboard' },
   { key: 'dashboard.ranking',      label: 'Ranking',           type: 'dashboard-tab', path: '/dashboard/ranking' },


### PR DESCRIPTION
Reorg de IA (2/2): fecha a relocação.

- Configurações ganha aba **Campanha SDR** (gate `sdr.parametros`) com atalho p/ `/sdr-ia/parametros` (página intacta) + breadcrumb de volta.
- Dashboard: 'SDR IA (Visão Geral)' → **'Visão geral'**.
- Removida a rota órfã `/sdr-ia/dashboard`; `lib/modules.ts` atualizado (path → /sdr-ia/disparos, label → 'SDR / Disparos').

tsc limpo. (Restam menções 'SDR IA' em copy descritiva do dashboard — opcional purgar depois.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)