### PR TITLE
fix: sidebar 'Visão geral' → 'Dashboard'

### DIFF
--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -26,7 +26,7 @@ const navItems: NavGroup[] = [
     section: 'Principal',
     items: [
       {
-        href: '/dashboard', label: 'Visão geral',
+        href: '/dashboard', label: 'Dashboard',
         icon: <LayoutGrid size={16} />,
         isActive: (p) => p.startsWith('/dashboard'),
       },


### PR DESCRIPTION
Rótulo do item de nav para /dashboard volta a 'Dashboard' (aba interna 'Visão Geral' e título da página inalterados).

🤖 Generated with [Claude Code](https://claude.com/claude-code)