### PR TITLE
refactor: helper único de data + padroniza 6 pontos

### DIFF
--- a/app/(app)/pipeline/page.tsx
+++ b/app/(app)/pipeline/page.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import { X } from 'lucide-react'
 import { formatCurrency, daysAgo } from '@/lib/utils'
+import { toDate } from '@/lib/date'
 
 type Priority = 'high' | 'normal' | 'low'
 
@@ -410,7 +411,8 @@ export default function PipelinePage() {
 
               {/* Cards */}
               {stage.leads.map(lead => {
-                const age = lead.updatedAt ? daysAgo(new Date(lead.updatedAt * 1000)) : 0
+                const _upd = toDate(lead.updatedAt)
+                const age = _upd ? daysAgo(_upd) : 0
                 const hasAlert = age > 7
                 const isDragging = draggingLeadId === lead.id
                 return (

--- a/app/(app)/sdr-ia/disparos/page.tsx
+++ b/app/(app)/sdr-ia/disparos/page.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from '@/components/Skeleton'
 import { Button } from '@/components/ui/Button'
 import { useQuery } from '@tanstack/react-query'
 import { useCanDispatch } from '@/lib/hooks/useCanDispatch'
+import { toMs } from '@/lib/date'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -47,15 +48,6 @@ interface DetailResponse {
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-
-// Aceita ISO string (o que a API serializa de um Date), número em ms ou em segundos.
-// Nunca devolve "Invalid Date": valor inválido vira null.
-function toMs(ts: string | number | null | undefined): number | null {
-  if (ts == null || ts === '') return null
-  if (typeof ts === 'number') return ts < 1e12 ? ts * 1000 : ts   // segundos → ms
-  const t = Date.parse(ts)                                        // string ISO
-  return Number.isNaN(t) ? null : t
-}
 
 function fmtDate(ts: string | number | null): string {
   const ms = toMs(ts)

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -6,6 +6,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useWhiteLabel } from '@/stores/whiteLabelStore'
 import { useUser } from '@/stores/userStore'
 import { initials } from '@/lib/utils'
+import { fmtDateBr } from '@/lib/date'
 import { Pencil, Trash2, Clock, Search, Check, Database, KeyRound } from 'lucide-react'
 import { ACTION_LABELS, fmtDateTime, fmtDetail } from '@/lib/audit-format'
 import { SparkleIcon } from '@/components/icons/SparkleIcon'
@@ -797,10 +798,7 @@ function textOn(hex: string) {
 }
 
 function fmtDate(d: string | number) {
-  try {
-    const dt = typeof d === 'number' ? new Date(d * 1000) : new Date(d)
-    return dt.toLocaleDateString('pt-BR')
-  } catch { return '—' }
+  return fmtDateBr(d)
 }
 
 function Field({ value, onChange, type = 'text', placeholder, disabled }: React.InputHTMLAttributes<HTMLInputElement>) {

--- a/app/(master)/master/page.tsx
+++ b/app/(master)/master/page.tsx
@@ -1,6 +1,7 @@
 import { db } from '@/lib/db'
 import { tenants, users } from '@/lib/db/schema'
 import { count, eq, desc } from 'drizzle-orm'
+import { fmtDateBr } from '@/lib/date'
 
 export default async function MasterDashboard() {
   const [totalTenantsRow, totalUsersRow, tenantRows] = await Promise.all([
@@ -84,9 +85,7 @@ export default async function MasterDashboard() {
                   {t.userCount}
                 </td>
                 <td style={{ padding: '14px 20px', fontSize: 12, color: '#888' }}>
-                  {t.createdAt instanceof Date
-                    ? t.createdAt.toLocaleDateString('pt-BR')
-                    : new Date(t.createdAt as number * 1000).toLocaleDateString('pt-BR')}
+                  {fmtDateBr(t.createdAt)}
                 </td>
                 <td style={{ padding: '14px 20px', textAlign: 'right' }}>
                   <a

--- a/app/(master)/master/tenants/[tenantId]/page.tsx
+++ b/app/(master)/master/tenants/[tenantId]/page.tsx
@@ -4,6 +4,7 @@ import { eq } from 'drizzle-orm'
 import { notFound } from 'next/navigation'
 import { getEnabledModuleKeys } from '@/lib/entitlements'
 import { TenantEditor } from './TenantEditor'
+import { fmtDateBr } from '@/lib/date'
 
 type Props = { params: Promise<{ tenantId: string }> }
 
@@ -44,9 +45,6 @@ export default async function TenantDetailPage({ params }: Props) {
     modules: modulesByPlan.get(p.id) ?? [],
   }))
 
-  const createdAtDate = tenant.createdAt instanceof Date
-    ? tenant.createdAt
-    : new Date((tenant.createdAt as number) * 1000)
 
   return (
     <div style={{ padding: '40px 48px', maxWidth: 1100 }}>
@@ -75,7 +73,7 @@ export default async function TenantDetailPage({ params }: Props) {
           {tenant.slug}
         </span>
         <span style={{ fontSize: 12, color: '#aaa' }}>
-          Criado em {createdAtDate.toLocaleDateString('pt-BR')}
+          Criado em {fmtDateBr(tenant.createdAt)}
         </span>
       </div>
 
@@ -113,9 +111,6 @@ export default async function TenantDetailPage({ params }: Props) {
           <tbody>
             {tenantUsers.map((u, i) => {
               const badge = ROLE_BADGE[u.role] ?? ROLE_BADGE.user
-              const uDate = u.createdAt instanceof Date
-                ? u.createdAt
-                : new Date((u.createdAt as number) * 1000)
               return (
                 <tr key={u.id} style={{ borderBottom: i < tenantUsers.length - 1 ? '1px solid #f0f0ee' : 'none' }}>
                   <td style={{ padding: '14px 20px', fontSize: 13, fontWeight: 700, color: '#121316' }}>
@@ -135,7 +130,7 @@ export default async function TenantDetailPage({ params }: Props) {
                     </span>
                   </td>
                   <td style={{ padding: '14px 20px', fontSize: 12, color: '#888' }}>
-                    {uDate.toLocaleDateString('pt-BR')}
+                    {fmtDateBr(u.createdAt)}
                   </td>
                 </tr>
               )

--- a/app/(master)/master/tenants/page.tsx
+++ b/app/(master)/master/tenants/page.tsx
@@ -1,6 +1,7 @@
 import { db } from '@/lib/db'
 import { tenants, users } from '@/lib/db/schema'
 import { count, eq, desc } from 'drizzle-orm'
+import { fmtDateBr } from '@/lib/date'
 
 export default async function TenantsPage() {
   const rows = await db
@@ -67,9 +68,7 @@ export default async function TenantsPage() {
                   {t.userCount}
                 </td>
                 <td style={{ padding: '14px 20px', fontSize: 12, color: '#888' }}>
-                  {t.createdAt instanceof Date
-                    ? t.createdAt.toLocaleDateString('pt-BR')
-                    : new Date(t.createdAt as number * 1000).toLocaleDateString('pt-BR')}
+                  {fmtDateBr(t.createdAt)}
                 </td>
                 <td style={{ padding: '14px 20px', textAlign: 'right' }}>
                   <a

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,0 +1,25 @@
+// Normalização de datas vindas de fontes mistas: Date (Drizzle em Server Components),
+// string ISO (serialização JSON de um Date numa API), ou número (ms ou segundos Unix).
+// Nunca produz "Invalid Date" — valor ausente/inválido vira null.
+
+export function toMs(ts: Date | string | number | null | undefined): number | null {
+  if (ts == null || ts === '') return null
+  if (ts instanceof Date) {
+    const t = ts.getTime()
+    return Number.isNaN(t) ? null : t
+  }
+  if (typeof ts === 'number') return ts < 1e12 ? ts * 1000 : ts   // < 1e12 = epoch em segundos → ms
+  const t = Date.parse(ts)                                        // string ISO
+  return Number.isNaN(t) ? null : t
+}
+
+export function toDate(ts: Date | string | number | null | undefined): Date | null {
+  const ms = toMs(ts)
+  return ms == null ? null : new Date(ms)
+}
+
+// Data curta pt-BR (dd/mm/aaaa) ou '—' se ausente/inválida.
+export function fmtDateBr(ts: Date | string | number | null | undefined): string {
+  const d = toDate(ts)
+  return d ? d.toLocaleDateString('pt-BR') : '—'
+}


### PR DESCRIPTION
Elimina a família de bugs de data ('Invalid Date'/datas erradas) com um util compartilhado.

- **lib/date.ts**: `toMs`/`toDate`/`fmtDateBr` — aceita Date | ISO string | número (ms ou segundos), nunca 'Invalid Date' (inválido → null/'—').
- Aplicado em: master (dashboard, tenants, detalhe do tenant), pipeline (idade do lead), settings (`fmtDate`) e disparos (usa o compartilhado, remove o local).
- Comportamento idêntico onde já funcionava (Server Components já tratavam Date); corrige onde o valor chega como ISO da API.

tsc limpo; grep de `*1000` de data zerado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)