### PR TITLE
feat: tendência nos KPIs da Visão geral (D2)

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -33,9 +33,17 @@ interface WaRates  { entrega: number; leitura: number }
 interface WaDay    { date: string; sent: number; delivered: number; read: number; failed: number; inbound: number }
 interface WaBlock  { totals: WaTotals; rates: WaRates; daily: WaDay[] }
 
+type Trend = 'up' | 'down' | 'flat'
+
 interface SdrBiData {
   period: string
   kpis: { contatos: number; taxaResposta: number; reunioes: number; conversao: number }
+  kpisChange?: {
+    contatos?:     { pct: number; trend: Trend } | null
+    taxaResposta?: { pp: number;  trend: Trend } | null
+    reunioes?:     { pct: number; trend: Trend } | null
+    conversao?:    { pp: number;  trend: Trend } | null
+  }
   funnel: { stageKey: string; stageName: string; count: number; order: number }[]
   sentiment: { id: string; label: string; color: string; count: number }[]
   recent: { sessionId: string; source: string; lastContact: number | null; msgs: number; name: string | null }[]
@@ -430,6 +438,8 @@ export default function DashboardPage() {
               value={data!.kpis.contatos}
               accent="var(--primary-text)"
               sub={`de ${(data?.funnel.find(f => f.stageKey === 'leads')?.count ?? 0).toLocaleString('pt-BR')} leads recebidos`}
+              change={data?.kpisChange?.contatos?.pct ?? null}
+              changeUnit="%"
             />
             <KpiCard
               className="animate-slide-up delay-3"
@@ -438,6 +448,8 @@ export default function DashboardPage() {
               format={v => `${v}%`}
               accent="#2563EB"
               sub="leads que responderam"
+              change={data?.kpisChange?.taxaResposta?.pp ?? null}
+              changeUnit="pp"
             />
             <KpiCard
               className="animate-slide-up delay-4"
@@ -445,6 +457,8 @@ export default function DashboardPage() {
               value={data!.kpis.reunioes}
               accent="var(--green)"
               sub="com closer neste período"
+              change={data?.kpisChange?.reunioes?.pct ?? null}
+              changeUnit="%"
             />
             <KpiCard
               className="animate-slide-up delay-5"
@@ -453,6 +467,8 @@ export default function DashboardPage() {
               format={v => `${v}%`}
               accent="var(--green)"
               sub="do total de leads"
+              change={data?.kpisChange?.conversao?.pp ?? null}
+              changeUnit="pp"
             />
           </div>
 

--- a/app/api/bi/sdr/route.ts
+++ b/app/api/bi/sdr/route.ts
@@ -60,6 +60,11 @@ export async function GET(request: Request) {
   const startMonth = toYearMonth(periodStart)
   const endMonth = toYearMonth(now)
 
+  // Prior period of equal length for KPI trend comparison
+  const priorStart = new Date(now.getTime() - 2 * days * DAY)
+  const priorStartMonth = toYearMonth(priorStart)
+  const priorEndMonth   = toYearMonth(periodStart)
+
   // ── Funnel snapshots: aggregate by stageKey over the period range ─────────
   const funnelRows = await db
     .select({
@@ -77,6 +82,21 @@ export async function GET(request: Request) {
     ))
     .groupBy(funnelSnapshots.stageKey, funnelSnapshots.stageName)
     .orderBy(sql`min(${funnelSnapshots.order})`)
+
+  // ── Prior-period funnel snapshot (same shape, previous window) ────────────
+  const priorFunnelRows = await db
+    .select({
+      stageKey: funnelSnapshots.stageKey,
+      count:    sql<number>`sum(${funnelSnapshots.count})`,
+    })
+    .from(funnelSnapshots)
+    .where(and(
+      eq(funnelSnapshots.tenantId, tenantId),
+      eq(funnelSnapshots.source, 'supabase-n8n'),
+      gte(funnelSnapshots.period, priorStartMonth),
+      lte(funnelSnapshots.period, priorEndMonth),
+    ))
+    .groupBy(funnelSnapshots.stageKey)
 
   // ── Events: sentiment (supabase-n8n only — YCloud events have null sentiment) ─
   const sentimentRows = await db
@@ -189,6 +209,38 @@ export async function GET(request: Request) {
     ? Math.round((responsesCount / contactedCount) * 100) : 0
   const conversao = leadsCount > 0
     ? Math.round((meetingsCount / leadsCount) * 100) : 0
+
+  // ── Prior-period KPIs and change computation ──────────────────────────────
+  type Trend = 'up' | 'down' | 'flat'
+  function trend(v: number): Trend { return v > 0 ? 'up' : v < 0 ? 'down' : 'flat' }
+
+  const priorMap = new Map(priorFunnelRows.map(r => [r.stageKey, Number(r.count)]))
+  const priorLeads     = priorMap.get('leads')     ?? 0
+  const priorContacted = priorMap.get('contacted') ?? 0
+  const priorResponses = priorMap.get('responses') ?? 0
+  const priorMeetings  = priorMap.get('meetings')  ?? 0
+
+  const priorTaxaResposta = priorContacted > 0
+    ? Math.round((priorResponses / priorContacted) * 100) : 0
+  const priorConversao = priorLeads > 0
+    ? Math.round((priorMeetings / priorLeads) * 100) : 0
+
+  const kpisChange = {
+    // Counts → % change; null when prior is 0 (no base for comparison)
+    contatos: priorContacted > 0
+      ? (() => { const pct = Math.round(((contactedCount - priorContacted) / priorContacted) * 100); return { pct, trend: trend(pct) } })()
+      : null,
+    reunioes: priorMeetings > 0
+      ? (() => { const pct = Math.round(((meetingsCount - priorMeetings) / priorMeetings) * 100); return { pct, trend: trend(pct) } })()
+      : null,
+    // Rates → pp diff; null when prior denominator was 0 (rate is not meaningful)
+    taxaResposta: priorContacted > 0
+      ? (() => { const pp = taxaResposta - priorTaxaResposta; return { pp, trend: trend(pp) } })()
+      : null,
+    conversao: priorLeads > 0
+      ? (() => { const pp = conversao - priorConversao; return { pp, trend: trend(pp) } })()
+      : null,
+  }
 
   // ── Sentiment donut ───────────────────────────────────────────────────────
   const sentMap = new Map<string, number>()
@@ -307,6 +359,7 @@ export async function GET(request: Request) {
   return NextResponse.json({
     period,
     kpis: { contatos: contactedCount, taxaResposta, reunioes: meetingsCount, conversao },
+    kpisChange,
     funnel: funnelRows.map(r => ({
       stageKey:  r.stageKey,
       stageName: r.stageName,

--- a/components/widgets/KpiCard.tsx
+++ b/components/widgets/KpiCard.tsx
@@ -31,7 +31,7 @@ export function useCountUp(target: number, duration = 750, delay = 0): number {
 
 // ─── ChangeBadge ─────────────────────────────────────────────────────────────
 
-export function ChangeBadge({ value }: { value: number | null }) {
+export function ChangeBadge({ value, unit = '%' }: { value: number | null; unit?: '%' | 'pp' }) {
   if (value === null || value === undefined) return null
   const positive = value > 0
   const zero = value === 0
@@ -48,7 +48,7 @@ export function ChangeBadge({ value }: { value: number | null }) {
       padding: '2px 8px',
       marginTop: 8,
     }}>
-      <Arrow size={11} /> {Math.abs(value)}% <span style={{ fontWeight: 500, opacity: 0.7 }}>vs ant.</span>
+      <Arrow size={11} /> {Math.abs(value)}{unit} <span style={{ fontWeight: 500, opacity: 0.7 }}>vs ant.</span>
     </span>
   )
 }
@@ -63,11 +63,12 @@ export interface KpiCardProps {
   sub?: string
   delay?: number
   change?: number | null
+  changeUnit?: '%' | 'pp'
   className?: string
 }
 
 export function KpiCard({
-  label, value, format, accent = 'var(--primary)', sub, delay = 0, change, className,
+  label, value, format, accent = 'var(--primary)', sub, delay = 0, change, changeUnit = '%', className,
 }: KpiCardProps) {
   const [hov, setHov] = useState(false)
   const counted = useCountUp(value, 750, delay)
@@ -105,7 +106,7 @@ export function KpiCard({
         wordBreak: 'break-all',
       }}>{display}</div>
       {sub && <div style={{ fontSize: 11, color: 'var(--muted)', marginTop: 5, fontWeight: 500 }}>{sub}</div>}
-      <ChangeBadge value={change ?? null} />
+      <ChangeBadge value={change ?? null} unit={changeUnit} />
     </div>
   )
 }


### PR DESCRIPTION
Melhorias do dashboard (2/3): os 4 KPIs de SDR ganham tendência vs o período anterior.

- `/api/bi/sdr`: 1 query extra (janela anterior, mês-bucket) → `kpisChange` (contagens %, taxas pp; null sem base).
- KpiCard ganha `changeUnit` (%/pp); badge ↑/↓ (verde melhora / vermelho piora).
- **Nota:** snapshots mensais → comparação direcional (compartilha o mês de fronteira). Crispness = redefinir períodos como meses-calendário (follow-up).

tsc limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)