### PR TITLE
feat: status da conversa na Visão geral (D3)

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -46,7 +46,7 @@ interface SdrBiData {
   }
   funnel: { stageKey: string; stageName: string; count: number; order: number }[]
   sentiment: { id: string; label: string; color: string; count: number }[]
-  recent: { sessionId: string; source: string; lastContact: number | null; msgs: number; name: string | null }[]
+  recent: { sessionId: string; source: string; lastContact: number | null; msgs: number; name: string | null; status: 'respondeu' | 'aguardando' | 'fria' }[]
   sourceConfigured: boolean
   whatsapp?: WaBlock
   lastSyncAt: number | null
@@ -147,6 +147,26 @@ function PeriodFilter({ value, onChange }: { value: Period; onChange: (p: Period
   )
 }
 
+function StatusBadge({ status }: { status: 'respondeu' | 'aguardando' | 'fria' }) {
+  const cfg = {
+    respondeu:  { label: 'Respondeu',  color: '#15803d', bg: 'rgba(34,197,94,0.10)',  border: 'rgba(34,197,94,0.25)'  },
+    aguardando: { label: 'Aguardando', color: '#b45309', bg: 'rgba(245,158,11,0.10)', border: 'rgba(245,158,11,0.30)' },
+    fria:       { label: 'Fria',       color: 'var(--gray2)', bg: 'rgba(170,170,170,0.10)', border: 'rgba(170,170,170,0.25)' },
+  }[status]
+  return (
+    <span style={{
+      display: 'inline-block',
+      fontSize: 10, fontWeight: 700,
+      padding: '2px 8px', borderRadius: 100,
+      background: cfg.bg, color: cfg.color,
+      border: `1px solid ${cfg.border}`,
+      whiteSpace: 'nowrap' as const,
+    }}>
+      {cfg.label}
+    </span>
+  )
+}
+
 function SourceBadge({ source }: { source: string }) {
   const isWa = source === 'ycloud-whatsapp'
   return (
@@ -181,6 +201,12 @@ const TABLE_COLS: DataTableColumn[] = [
     label: 'Origem',
     sortable: false,
     format: (v) => <SourceBadge source={v as string} />,
+  },
+  {
+    key: 'status',
+    label: 'Status',
+    sortable: true,
+    format: (v) => <StatusBadge status={v as 'respondeu' | 'aguardando' | 'fria'} />,
   },
   {
     key: 'sessionLabel',
@@ -351,6 +377,7 @@ export default function DashboardPage() {
     sessionId:    r.sessionId,
     msgs:         r.msgs,
     lastContact:  r.lastContact ?? 0,
+    status:       r.status,
   }))
 
   // WhatsApp derived data — fallback to zeros so section never crashes

--- a/app/api/bi/sdr/route.ts
+++ b/app/api/bi/sdr/route.ts
@@ -121,6 +121,7 @@ export async function GET(request: Request) {
       source:     conversations.source,
       sessionId:  conversations.sessionId,
       occurredAt: conversations.occurredAt,
+      role:       conversations.role,
     })
     .from(conversations)
     .where(and(
@@ -257,22 +258,34 @@ export async function GET(request: Request) {
 
   // ── Recent sessions: dedup by (source, sessionId); top 50 by recência ────
   //    Key = `${source}:${sessionId}` so same phone in YCloud and SDR don't collapse
-  const sessionMap = new Map<string, { source: string; sessionId: string; lastContact: number | null; msgs: number }>()
+  const COLD_MS = 7 * DAY
+  const sessionMap = new Map<string, { source: string; sessionId: string; lastContact: number | null; msgs: number; lastRole: string | null }>()
   for (const row of convRows) {
     const key = `${row.source}:${row.sessionId}`
     const ms  = row.occurredAt instanceof Date ? row.occurredAt.getTime() : null
     const ex  = sessionMap.get(key)
     if (!ex) {
-      sessionMap.set(key, { source: row.source, sessionId: row.sessionId, lastContact: ms, msgs: 1 })
+      // First row is the most recent (DESC order) — captures lastRole and lastContact
+      sessionMap.set(key, { source: row.source, sessionId: row.sessionId, lastContact: ms, msgs: 1, lastRole: row.role })
     } else {
       ex.msgs++
-      if (ms && (!ex.lastContact || ms > ex.lastContact)) ex.lastContact = ms
+      if (ms && (!ex.lastContact || ms > ex.lastContact)) {
+        ex.lastContact = ms
+        ex.lastRole    = row.role
+      }
     }
   }
+  const nowMs = now.getTime()
   const recent = Array.from(sessionMap.values())
     .sort((a, b) => (b.lastContact ?? 0) - (a.lastContact ?? 0))
     .slice(0, 50)
-    .map(({ source, sessionId, lastContact, msgs }) => ({ sessionId, source, lastContact, msgs }))
+    .map(({ source, sessionId, lastContact, msgs, lastRole }) => {
+      const status: 'respondeu' | 'aguardando' | 'fria' =
+        lastContact !== null && nowMs - lastContact > COLD_MS ? 'fria'
+        : lastRole === 'human' ? 'respondeu'
+        : 'aguardando'
+      return { sessionId, source, lastContact, msgs, status }
+    })
 
   // ── Name lookup: match recent sessionIds against contacts ─────────────────
   // supabase-n8n sessionIds are plain digits (no '+'); YCloud contacts store


### PR DESCRIPTION
Melhorias do dashboard (3/3): a tabela de sessões mostra qual conversa priorizar.

- `/api/bi/sdr`: deriva `status` por sessão da última msg + recência — **fria** (>7d sem atividade), **respondeu** (lead respondeu por último), **aguardando** (assistente mandou por último).
- Tabela ganha coluna **Status** (badge verde/âmbar/cinza); clique segue indo p/ a conversa.

tsc limpo. Fecha a leva de melhorias da Visão geral (D1+D2+D3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)