### PR TITLE
feat: endpoint de lead manual (M1)

### DIFF
--- a/app/api/sdr/leads/import/route.ts
+++ b/app/api/sdr/leads/import/route.ts
@@ -18,74 +18,13 @@ import { decrypt } from '@/lib/crypto'
 import { assertEntitlement } from '@/lib/entitlements'
 import { Client } from 'pg'
 import * as XLSX from 'xlsx'
+import { mapKey, normalizePhone, phoneKey, firstWord } from '@/lib/sdr/leads-etl'
 
 const PROVIDER_KEY   = 'supabase-n8n'
 const SOURCE         = 'sdr-n8n'
 const MAX_FILE_BYTES = 5 * 1024 * 1024  // 5 MB
 const MAX_ROWS       = 1000
 const AMOSTRA_MAX    = 20
-const E164_RE        = /^\+[1-9]\d{6,14}$/
-
-// Maps spreadsheet header (PT or EN) to internal canonical key.
-function mapKey(raw: string): string {
-  switch (raw.toLowerCase().trim()) {
-    case 'nome':     case 'name':                        return 'name'
-    case 'telefone': case 'phone': case 'tel':
-    case 'celular':                                      return 'phone'
-    case 'empresa':  case 'company':                     return 'company'
-    case 'origem':   case 'source':                      return 'source'
-    case 'status':                                       return 'status'
-    default:                                             return raw.toLowerCase().trim()
-  }
-}
-
-// Normalizes a phone string to E.164. Returns null if the result is not valid E.164.
-// Strategy: keep only digits and leading +; if no +, assume Brazil (+55) when < 12 digits.
-function normalizePhone(raw: string): string | null {
-  if (!raw) return null
-  const stripped = raw.replace(/[^\d+]/g, '')
-  if (!stripped) return null
-
-  let normalized: string
-  if (stripped.startsWith('+')) {
-    normalized = stripped
-  } else {
-    // No + prefix: use digit count to guess whether country code is present.
-    // Brazilian numbers without DDI are 10–11 digits (DDD + number).
-    // With +55 they become 12–13 digits.
-    normalized = stripped.length >= 12 ? '+' + stripped : '+55' + stripped
-  }
-
-  return E164_RE.test(normalized) ? normalized : null
-}
-
-// Canonical dedup key — format-agnostic, comparable across the file and the DB.
-// Produces DDD(2) + 8 digits, collapsing the 9th-digit mobile prefix so that
-// "+5511 9 8888-7777" and the DB value "551188887777" both yield "1188887777".
-// Returns null when the input cannot be reduced to a valid key.
-function phoneKey(raw: string): string | null {
-  if (!raw) return null
-  const digits = raw.replace(/\D/g, '')
-  if (!digits) return null
-
-  let national = digits
-
-  // Strip Brazil DDI when present and remainder is 10 or 11 digits (12/13 total)
-  if (national.startsWith('55') && (national.length === 12 || national.length === 13)) {
-    national = national.slice(2)
-  }
-
-  // Remove 9th-digit mobile prefix: DDD(2) + '9' + 8 digits → DDD(2) + 8 digits
-  if (national.length === 11 && national[2] === '9') {
-    national = national.slice(0, 2) + national.slice(3)
-  }
-
-  return national.length >= 10 ? national : null
-}
-
-function firstWord(s: unknown): string {
-  return String(s ?? '').trim().split(/\s+/)[0] ?? ''
-}
 
 export async function POST(request: Request) {
   const session = await auth()

--- a/app/api/sdr/leads/manual/route.ts
+++ b/app/api/sdr/leads/manual/route.ts
@@ -1,0 +1,184 @@
+// POST /api/sdr/leads/manual
+//
+// Accepts a single lead as JSON, validates/deduplicates, and inserts via n8n
+// (same webhook as /api/sdr/leads/import). Never writes to Supabase directly.
+//
+// Request body: { name: string, phone: string, company?: string }
+//
+// Responses:
+//   200  { ok: true, leadId: string, duplicate: true,  name: string }  — already exists
+//   200  { ok: true, leadId: string, duplicate: false, name: string }  — inserted via n8n
+//   400  { error: string }                                              — validation / config
+//   502  { ok: false, error: string }                                  — n8n unreachable
+//   500  { ok: false, error: string }                                  — unexpected
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { dataSources, campaignSettings } from '@/lib/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { decrypt } from '@/lib/crypto'
+import { assertEntitlement } from '@/lib/entitlements'
+import { Client } from 'pg'
+import { normalizePhone, phoneKey } from '@/lib/sdr/leads-etl'
+
+const PROVIDER_KEY = 'supabase-n8n'
+const SOURCE       = 'sdr-n8n'
+
+export async function POST(request: Request) {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { tenantId } = session.user
+  const denied = await assertEntitlement(tenantId, 'sdr.parametros')
+  if (denied) return denied
+
+  // ── Parse + validate body ─────────────────────────────────────────────────
+  let body: Record<string, unknown>
+  try {
+    body = await request.json() as Record<string, unknown>
+  } catch {
+    return NextResponse.json({ error: 'Body JSON inválido' }, { status: 400 })
+  }
+
+  const name    = typeof body.name    === 'string' ? body.name.trim()    : ''
+  const rawPhone = typeof body.phone  === 'string' ? body.phone.trim()   : ''
+  const company = typeof body.company === 'string' ? body.company.trim() : ''
+
+  if (!name) {
+    return NextResponse.json({ error: 'nome_obrigatorio' }, { status: 400 })
+  }
+
+  const phone = normalizePhone(rawPhone)
+  if (!phone) {
+    return NextResponse.json({ error: 'telefone_invalido' }, { status: 400 })
+  }
+
+  const key = phoneKey(phone)
+  if (!key) {
+    return NextResponse.json({ error: 'telefone_invalido' }, { status: 400 })
+  }
+
+  // ── Load n8nImportUrl + secret ────────────────────────────────────────────
+  const [csRow] = await db
+    .select()
+    .from(campaignSettings)
+    .where(and(eq(campaignSettings.tenantId, tenantId), eq(campaignSettings.source, SOURCE)))
+    .limit(1)
+
+  let csSettings: Record<string, unknown> = {}
+  if (csRow) {
+    try { csSettings = JSON.parse(csRow.settings) } catch {}
+  }
+
+  const importUrl =
+    typeof csSettings.n8nImportUrl === 'string' && csSettings.n8nImportUrl
+      ? csSettings.n8nImportUrl
+      : null
+
+  if (!importUrl) {
+    return NextResponse.json({ error: 'import_url_nao_configurada' }, { status: 400 })
+  }
+
+  const importSecret =
+    typeof csSettings.n8nImportSecret === 'string' && csSettings.n8nImportSecret
+      ? csSettings.n8nImportSecret
+      : undefined
+
+  // ── Dedup against Supabase (SELECT only — never writes) ───────────────────
+  let existingId:   string | null = null
+  let existingName: string | null = null
+
+  try {
+    const dsRow = await db
+      .select()
+      .from(dataSources)
+      .where(and(
+        eq(dataSources.tenantId, tenantId),
+        eq(dataSources.providerKey, PROVIDER_KEY),
+      ))
+      .then(r => r[0])
+
+    if (dsRow?.configEnc) {
+      const cfg = JSON.parse(decrypt(dsRow.configEnc)) as { connectionString?: string }
+      if (cfg.connectionString) {
+        const pgClient = new Client({ connectionString: cfg.connectionString })
+        try {
+          await pgClient.connect()
+          const res = await pgClient.query<{
+            id: string; name: string | null; phone: string | null; phone_adjusted: string | null
+          }>(
+            `SELECT id, name, phone, phone_adjusted
+               FROM leads
+              WHERE phone IS NOT NULL OR phone_adjusted IS NOT NULL`,
+          )
+          for (const r of res.rows) {
+            const k1 = phoneKey(r.phone ?? '')
+            const k2 = phoneKey(r.phone_adjusted ?? '')
+            if ((k1 && k1 === key) || (k2 && k2 === key)) {
+              existingId   = r.id
+              existingName = r.name
+              break
+            }
+          }
+        } finally {
+          await pgClient.end().catch(() => {})
+        }
+      }
+    }
+  } catch (err) {
+    // Non-fatal: if Supabase is unavailable, skip dedup and proceed to insert.
+    // n8n will enforce its own constraints.
+    console.error('[sdr manual dedup]', err)
+  }
+
+  if (existingId) {
+    return NextResponse.json({
+      ok: true,
+      leadId: existingId,
+      duplicate: true,
+      name: existingName ?? name,
+    })
+  }
+
+  // ── POST new lead to n8n ──────────────────────────────────────────────────
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (importSecret) headers['Authorization'] = `Bearer ${importSecret}`
+
+  let leadId: string | null = null
+  try {
+    const res = await fetch(importUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        tenantId,
+        leads: [{ name, phone, company: company || null, source: 'manual', status: 'novo' }],
+      }),
+      signal: AbortSignal.timeout(15_000),
+    })
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      console.error('[sdr manual → n8n] status', res.status, text)
+      return NextResponse.json(
+        { ok: false, error: `n8n retornou ${res.status}` },
+        { status: 502 },
+      )
+    }
+
+    try {
+      const body2 = await res.json() as Record<string, unknown>
+      const ids   = Array.isArray(body2.ids) ? body2.ids as unknown[] : []
+      const first = ids[0]
+      if (typeof first === 'string') leadId = first
+    } catch { /* non-JSON body — leadId stays null */ }
+  } catch (err) {
+    console.error('[sdr manual → n8n]', err)
+    return NextResponse.json(
+      { ok: false, error: 'Falha ao enviar para importação: ' + (err instanceof Error ? err.message : String(err)) },
+      { status: 502 },
+    )
+  }
+
+  return NextResponse.json({ ok: true, leadId, duplicate: false, name })
+}

--- a/lib/sdr/leads-etl.ts
+++ b/lib/sdr/leads-etl.ts
@@ -1,0 +1,70 @@
+// Pure ETL helpers shared by /api/sdr/leads/import and /api/sdr/leads/manual.
+// No side effects, no DB access, no external dependencies.
+
+const E164_RE = /^\+[1-9]\d{6,14}$/
+
+/** Maps spreadsheet header (PT or EN) to internal canonical key. */
+export function mapKey(raw: string): string {
+  switch (raw.toLowerCase().trim()) {
+    case 'nome':     case 'name':                        return 'name'
+    case 'telefone': case 'phone': case 'tel':
+    case 'celular':                                      return 'phone'
+    case 'empresa':  case 'company':                     return 'company'
+    case 'origem':   case 'source':                      return 'source'
+    case 'status':                                       return 'status'
+    default:                                             return raw.toLowerCase().trim()
+  }
+}
+
+/**
+ * Normalizes a phone string to E.164. Returns null if the result is not valid E.164.
+ * Strategy: keep only digits and leading +; if no +, assume Brazil (+55) when < 12 digits.
+ */
+export function normalizePhone(raw: string): string | null {
+  if (!raw) return null
+  const stripped = raw.replace(/[^\d+]/g, '')
+  if (!stripped) return null
+
+  let normalized: string
+  if (stripped.startsWith('+')) {
+    normalized = stripped
+  } else {
+    // No + prefix: use digit count to guess whether country code is present.
+    // Brazilian numbers without DDI are 10–11 digits (DDD + number).
+    // With +55 they become 12–13 digits.
+    normalized = stripped.length >= 12 ? '+' + stripped : '+55' + stripped
+  }
+
+  return E164_RE.test(normalized) ? normalized : null
+}
+
+/**
+ * Canonical dedup key — format-agnostic, comparable across the file and the DB.
+ * Produces DDD(2) + 8 digits, collapsing the 9th-digit mobile prefix so that
+ * "+5511 9 8888-7777" and the DB value "551188887777" both yield "1188887777".
+ * Returns null when the input cannot be reduced to a valid key.
+ */
+export function phoneKey(raw: string): string | null {
+  if (!raw) return null
+  const digits = raw.replace(/\D/g, '')
+  if (!digits) return null
+
+  let national = digits
+
+  // Strip Brazil DDI when present and remainder is 10 or 11 digits (12/13 total)
+  if (national.startsWith('55') && (national.length === 12 || national.length === 13)) {
+    national = national.slice(2)
+  }
+
+  // Remove 9th-digit mobile prefix: DDD(2) + '9' + 8 digits → DDD(2) + 8 digits
+  if (national.length === 11 && national[2] === '9') {
+    national = national.slice(0, 2) + national.slice(3)
+  }
+
+  return national.length >= 10 ? national : null
+}
+
+/** Returns the first word of a string, or empty string. */
+export function firstWord(s: unknown): string {
+  return String(s ?? '').trim().split(/\s+/)[0] ?? ''
+}


### PR DESCRIPTION
Adicionar lead manual (1/2): backend.

- ETL extraído p/ `lib/sdr/leads-etl.ts` (funções verbatim; import passa a importar de lá — comportamento idêntico).
- `POST /api/sdr/leads/manual` { name, phone, company? }: valida (E.164), deduplica no Supabase (só SELECT), insere via n8n (`n8nImportUrl`, `source:'manual'`), devolve `leadId`/`duplicate`. App nunca escreve no Supabase; sem mudança no fluxo n8n.

tsc limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)