### PR TITLE
feat: adicionar lead manual — UI (M2)

### DIFF
--- a/app/(app)/sdr-ia/disparos/page.tsx
+++ b/app/(app)/sdr-ia/disparos/page.tsx
@@ -1,11 +1,14 @@
 'use client'
 import { useState, useCallback } from 'react'
-import { ArrowLeft, RefreshCw, Download, RotateCcw } from 'lucide-react'
+import Link from 'next/link'
+import { ArrowLeft, RefreshCw, Download, RotateCcw, UserPlus, Check } from 'lucide-react'
 import { Skeleton } from '@/components/Skeleton'
 import { Button } from '@/components/ui/Button'
 import { useQuery } from '@tanstack/react-query'
 import { useCanDispatch } from '@/lib/hooks/useCanDispatch'
 import { toMs } from '@/lib/date'
+import { AddLeadForm } from '@/components/leads/AddLeadForm'
+import type { AddedInfo } from '@/components/leads/AddLeadForm'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -471,9 +474,11 @@ function CampaignRow({ c, onClick }: { c: Campaign; onClick: () => void }) {
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function DisparosPage() {
-  const [selectedId, setSelectedId] = useState<string | null>(null)
-  const [activeKind,  setActiveKind]  = useState<CampaignKind>('manual')
-  const [listKey,     setListKey]     = useState(0)
+  const [selectedId,   setSelectedId]   = useState<string | null>(null)
+  const [activeKind,   setActiveKind]   = useState<CampaignKind>('manual')
+  const [listKey,      setListKey]      = useState(0)
+  const [showAddLead,  setShowAddLead]  = useState(false)
+  const [addLeadDone,  setAddLeadDone]  = useState<AddedInfo | null>(null)
 
   const { data, isLoading, isError, refetch } = useQuery<{ campaigns: Campaign[] }>({
     queryKey: ['blast-campaigns', activeKind, listKey],
@@ -508,8 +513,77 @@ export default function DisparosPage() {
             Histórico de campanhas enviadas e status de entrega.
           </div>
         </div>
-        <PillBtn onClick={refresh} icon={<RefreshCw size={13} />} label="Atualizar" />
+        <div style={{ display: 'flex', gap: 8 }}>
+          <PillBtn onClick={() => { setAddLeadDone(null); setShowAddLead(true) }} icon={<UserPlus size={13} />} label="Adicionar lead" />
+          <PillBtn onClick={refresh} icon={<RefreshCw size={13} />} label="Atualizar" />
+        </div>
       </div>
+
+      {/* Add lead modal */}
+      {showAddLead && (
+        <div
+          style={{
+            position: 'fixed', inset: 0, zIndex: 9999,
+            background: 'rgba(0,0,0,0.40)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            padding: 24, animation: 'fadeIn .12s ease both',
+          }}
+          onClick={() => { setShowAddLead(false); setAddLeadDone(null) }}
+        >
+          <div
+            style={{
+              background: 'var(--white)', borderRadius: 20, padding: 28,
+              width: '100%', maxWidth: 420,
+              boxShadow: '0 24px 64px rgba(0,0,0,0.20)',
+              animation: 'modalSlideUp .18s cubic-bezier(0.22,1,0.36,1) both',
+            }}
+            onClick={e => e.stopPropagation()}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 20 }}>
+              <div style={{ fontSize: 16, fontWeight: 800, color: 'var(--black)', display: 'flex', alignItems: 'center', gap: 8 }}>
+                <UserPlus size={16} /> Adicionar lead
+              </div>
+              <button
+                onClick={() => { setShowAddLead(false); setAddLeadDone(null) }}
+                style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--gray2)', fontSize: 22, lineHeight: 1, padding: '0 4px' }}
+                aria-label="Fechar"
+              >
+                &times;
+              </button>
+            </div>
+
+            {addLeadDone ? (
+              <div>
+                <div style={{
+                  display: 'flex', alignItems: 'flex-start', gap: 8,
+                  padding: '12px 16px', borderRadius: 12, marginBottom: 18,
+                  background: 'rgba(34,197,94,0.07)', border: '1px solid rgba(34,197,94,0.25)',
+                  fontSize: 13, fontWeight: 600, color: '#15803d',
+                }}>
+                  <Check size={14} style={{ flexShrink: 0, marginTop: 1 }} />
+                  <span>
+                    {addLeadDone.duplicate
+                      ? <>Lead <strong>{addLeadDone.name}</strong> já existia &mdash; reaproveitado na base.</>
+                      : <>Lead <strong>{addLeadDone.name}</strong> adicionado à base.</>}
+                  </span>
+                </div>
+                <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'center' }}>
+                  <Button variant="secondary" size="sm" onClick={() => setAddLeadDone(null)}>Adicionar outro</Button>
+                  <Button variant="ghost"     size="sm" onClick={() => { setShowAddLead(false); setAddLeadDone(null) }}>Fechar</Button>
+                  <Link
+                    href="/sdr-ia/leads"
+                    style={{ fontSize: 12, fontWeight: 700, color: 'var(--primary-text)', textDecoration: 'underline' }}
+                  >
+                    Ir para Novo disparo &rarr;
+                  </Link>
+                </div>
+              </div>
+            ) : (
+              <AddLeadForm onAdded={info => setAddLeadDone(info)} />
+            )}
+          </div>
+        </div>
+      )}
 
       {/* Tabs */}
       <div className="animate-slide-up delay-1">

--- a/app/(app)/sdr-ia/leads/page.tsx
+++ b/app/(app)/sdr-ia/leads/page.tsx
@@ -6,6 +6,7 @@ import { SkeletonTable } from '@/components/Skeleton'
 import { Button } from '@/components/ui/Button'
 import { useCountUp } from '@/components/widgets/KpiCard'
 import { useCanDispatch } from '@/lib/hooks/useCanDispatch'
+import { AddLeadForm } from '@/components/leads/AddLeadForm'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -56,7 +57,7 @@ interface EnrollResult {
 }
 
 type Step   = 1 | 2 | 3
-type Source = 'base' | 'import'
+type Source = 'base' | 'import' | 'manual'
 type Action = 'blast' | 'enroll' | null
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -316,6 +317,9 @@ export default function NovDisparoPage() {
   const [selected,     setSelected]     = useState<Set<string>>(new Set())
   const masterRef = useRef<HTMLInputElement>(null)
 
+  // ── Step 1: manual ───────────────────────────────────────────────────────────
+  const [manualIds, setManualIds] = useState<Set<string>>(new Set())
+
   // ── Step 1: import ────────────────────────────────────────────────────────────
   const [importing,    setImporting]    = useState(false)
   const [showBar,      setShowBar]      = useState(false)
@@ -343,7 +347,7 @@ export default function NovDisparoPage() {
     ...(importResult?.leadIds ?? []),
     ...(importResult?.existingLeadIds ?? []),
   ])
-  const recipientIds    = source === 'base' ? selected : importedIds
+  const recipientIds    = source === 'base' ? selected : source === 'import' ? importedIds : manualIds
   const recipientCount  = recipientIds.size
   const names           = source === 'import' ? (importResult?.names ?? {}) : {}
   const semNome         = source === 'import' ? (importResult?.semNome ?? 0) : 0
@@ -553,6 +557,7 @@ export default function NovDisparoPage() {
     setSource('base')
     setAction(null)
     setSelected(new Set())
+    setManualIds(new Set())
     setImportResult(null)
     setSelectedTemplate('')
     setBlastTemplates(null)
@@ -578,20 +583,25 @@ export default function NovDisparoPage() {
 
           {/* Source toggle */}
           <div style={{ display: 'inline-flex', borderRadius: 10, border: '1px solid var(--gray3)', overflow: 'hidden', marginBottom: 20, background: 'var(--bg)' }}>
-            {(['base', 'import'] as const).map(s => (
+            {([
+              { id: 'base'   as const, label: 'Selecionar da base' },
+              { id: 'import' as const, label: 'Importar planilha'  },
+              { id: 'manual' as const, label: 'Adicionar manualmente', icon: <UserPlus size={12} style={{ flexShrink: 0 }} /> },
+            ]).map(s => (
               <button
-                key={s}
-                onClick={() => setSource(s)}
+                key={s.id}
+                onClick={() => setSource(s.id)}
                 style={{
                   padding: '8px 18px', fontSize: 12, fontWeight: 700,
                   border: 'none', cursor: 'pointer', fontFamily: 'inherit',
-                  background: source === s ? 'var(--white)' : 'transparent',
-                  color: source === s ? 'var(--black)' : 'var(--gray2)',
-                  boxShadow: source === s ? '0 1px 4px rgba(0,0,0,0.08)' : 'none',
+                  display: 'flex', alignItems: 'center', gap: 5,
+                  background: source === s.id ? 'var(--white)' : 'transparent',
+                  color: source === s.id ? 'var(--black)' : 'var(--gray2)',
+                  boxShadow: source === s.id ? '0 1px 4px rgba(0,0,0,0.08)' : 'none',
                   transition: 'all .15s',
                 }}
               >
-                {s === 'base' ? 'Selecionar da base' : 'Importar planilha'}
+                {s.icon}{s.label}
               </button>
             ))}
           </div>
@@ -790,6 +800,27 @@ export default function NovDisparoPage() {
                 </div>
               )}
             </>
+          )}
+
+          {/* ── MANUAL mode ──────────────────────────────────────────────────── */}
+          {source === 'manual' && (
+            <div style={{ maxWidth: 420 }}>
+              <div style={{ fontSize: 13, color: 'var(--gray)', marginBottom: 16, lineHeight: 1.55 }}>
+                Cadastre um lead manualmente. Cada lead adicionado entra automaticamente na seleção de destinatários.
+              </div>
+              <AddLeadForm
+                onAdded={info => {
+                  if (info.leadId) {
+                    setManualIds(prev => new Set([...prev, info.leadId!]))
+                  }
+                }}
+              />
+              {manualIds.size > 0 && (
+                <div style={{ marginTop: 14, fontSize: 12, color: 'var(--gray2)', fontWeight: 500 }}>
+                  {manualIds.size} lead{manualIds.size !== 1 ? 's' : ''} adicionado{manualIds.size !== 1 ? 's' : ''} nesta sessão
+                </div>
+              )}
+            </div>
           )}
 
           {/* ── Footer ─────────────────────────────────────────────────────── */}
@@ -1006,7 +1037,7 @@ export default function NovDisparoPage() {
                   <div style={{ display: 'flex', gap: 8 }}>
                     <span style={{ fontSize: 13, color: 'var(--gray)', fontWeight: 600, minWidth: 120 }}>Origem</span>
                     <span style={{ fontSize: 13, color: 'var(--black)', fontWeight: 700 }}>
-                      {source === 'base' ? 'Seleção da base' : 'Planilha importada'}
+                      {source === 'base' ? 'Seleção da base' : source === 'import' ? 'Planilha importada' : 'Adição manual'}
                     </span>
                   </div>
                   <div style={{ display: 'flex', gap: 8 }}>

--- a/components/leads/AddLeadForm.tsx
+++ b/components/leads/AddLeadForm.tsx
@@ -1,0 +1,170 @@
+'use client'
+import { useState } from 'react'
+import { UserPlus, Check, AlertTriangle, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+
+interface ManualLeadResult {
+  ok: boolean
+  leadId: string | null
+  duplicate: boolean
+  name: string
+  error?: string
+}
+
+export interface AddedInfo {
+  leadId: string | null
+  name: string
+  duplicate: boolean
+}
+
+interface AddLeadFormProps {
+  onAdded?: (info: AddedInfo) => void
+}
+
+function fieldStyle(focused: boolean): React.CSSProperties {
+  return {
+    width: '100%', boxSizing: 'border-box' as const,
+    padding: '9px 12px', fontSize: 13, fontFamily: 'inherit',
+    border: `1px solid ${focused ? 'var(--primary)' : 'var(--gray3)'}`,
+    borderRadius: 10,
+    background: 'var(--white)', color: 'var(--black)', outline: 'none',
+    transition: 'border-color .15s',
+  }
+}
+
+export function AddLeadForm({ onAdded }: AddLeadFormProps) {
+  const [name,       setName]       = useState('')
+  const [phone,      setPhone]      = useState('')
+  const [company,    setCompany]    = useState('')
+  const [focusedField, setFocused]  = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [last, setLast] = useState<(AddedInfo & { error?: string }) | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!name.trim() || !phone.trim() || submitting) return
+    setSubmitting(true)
+    setLast(null)
+    try {
+      const res  = await fetch('/api/sdr/leads/manual', {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify({
+          name:    name.trim(),
+          phone:   phone.trim(),
+          company: company.trim() || undefined,
+        }),
+      })
+      const data = await res.json() as ManualLeadResult
+      if (!res.ok || !data.ok) {
+        const msg = data.error === 'telefone_invalido'            ? 'Telefone inválido — use o formato +55 11 99999-9999.'
+                  : data.error === 'nome_obrigatorio'             ? 'Nome é obrigatório.'
+                  : data.error === 'import_url_nao_configurada'   ? 'URL de importação não configurada — acesse Configurações > Credenciais.'
+                  : (data.error ?? `Erro HTTP ${res.status}`)
+        setLast({ leadId: null, name: name.trim(), duplicate: false, error: msg })
+        return
+      }
+      const info: AddedInfo = { leadId: data.leadId, name: data.name, duplicate: data.duplicate }
+      setLast(info)
+      setName('')
+      setPhone('')
+      setCompany('')
+      onAdded?.(info)
+    } catch (err) {
+      setLast({ leadId: null, name: name.trim(), duplicate: false, error: (err as Error).message })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const labelStyle: React.CSSProperties = {
+    display: 'block', fontSize: 11, fontWeight: 700, color: 'var(--gray)',
+    textTransform: 'uppercase' as const, letterSpacing: '0.06em', marginBottom: 5,
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+
+        <div>
+          <label style={labelStyle}>Nome *</label>
+          <input
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="Nome do lead"
+            required
+            style={fieldStyle(focusedField === 'name')}
+            onFocus={() => setFocused('name')}
+            onBlur={() => setFocused(null)}
+          />
+        </div>
+
+        <div>
+          <label style={labelStyle}>Telefone *</label>
+          <input
+            value={phone}
+            onChange={e => setPhone(e.target.value)}
+            placeholder="+55 11 99999-9999"
+            required
+            type="tel"
+            style={fieldStyle(focusedField === 'phone')}
+            onFocus={() => setFocused('phone')}
+            onBlur={() => setFocused(null)}
+          />
+        </div>
+
+        <div>
+          <label style={labelStyle}>Empresa</label>
+          <input
+            value={company}
+            onChange={e => setCompany(e.target.value)}
+            placeholder="Empresa (opcional)"
+            style={fieldStyle(focusedField === 'company')}
+            onFocus={() => setFocused('company')}
+            onBlur={() => setFocused(null)}
+          />
+        </div>
+
+        <Button
+          type="submit"
+          variant="primary"
+          disabled={submitting || !name.trim() || !phone.trim()}
+          style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7 }}
+        >
+          {submitting
+            ? <><Loader2 size={14} style={{ animation: 'spin 1s linear infinite' }} /> Cadastrando...</>
+            : <><UserPlus size={14} /> Adicionar lead</>}
+        </Button>
+
+        {last && !last.error && (
+          <div style={{
+            display: 'flex', alignItems: 'flex-start', gap: 8,
+            padding: '10px 14px', borderRadius: 10,
+            background: 'rgba(34,197,94,0.07)', border: '1px solid rgba(34,197,94,0.25)',
+            fontSize: 13, fontWeight: 600, color: '#15803d',
+          }}>
+            <Check size={14} style={{ flexShrink: 0, marginTop: 1 }} />
+            <span>
+              {last.duplicate
+                ? <>Lead <strong>{last.name}</strong> já existia &mdash; reaproveitado.</>
+                : <>Lead <strong>{last.name}</strong> adicionado.</>}
+            </span>
+          </div>
+        )}
+
+        {last?.error && (
+          <div style={{
+            display: 'flex', alignItems: 'flex-start', gap: 8,
+            padding: '10px 14px', borderRadius: 10,
+            background: 'rgba(239,68,68,0.06)', border: '1px solid rgba(239,68,68,0.25)',
+            fontSize: 13, fontWeight: 600, color: 'var(--red)',
+          }}>
+            <AlertTriangle size={14} style={{ flexShrink: 0, marginTop: 1 }} />
+            <span>{last.error}</span>
+          </div>
+        )}
+
+      </div>
+    </form>
+  )
+}


### PR DESCRIPTION
Adicionar lead manual (2/2): UI.

- `components/leads/AddLeadForm.tsx`: Nome/Telefone/Empresa → `POST /api/sdr/leads/manual`; feedback de sucesso/duplicado/erro (acentos ok).
- Wizard 'Novo disparo': 3ª fonte **Adicionar manualmente** — cada lead entra na seleção do disparo.
- Disparos: atalho **+ Adicionar lead** (modal; cadastra na base sem disparar; não gateado por papel).

tsc limpo; sem emoji cru.

🤖 Generated with [Claude Code](https://claude.com/claude-code)